### PR TITLE
added new util shape_fitter to fit a circle on a binary mask

### DIFF
--- a/arte/utils/shape_fitter.py
+++ b/arte/utils/shape_fitter.py
@@ -1,0 +1,117 @@
+from skimage import measure, feature, io, color, draw
+from skimage import io, color, measure, draw, img_as_bool
+from scipy import optimize
+import numpy as np
+import matplotlib.pyplot as plt
+from pickle import NONE, TRUE
+
+class ShapeFitter(object):
+    ''' The class will provide a shape fitter on a binary mask. Currently is 
+    only possible to fit a circular shape 
+    
+    
+    pupilfit
+    Use RANSAC algoritm on the full mask or on the edge (using Canny as edge detector) to estimate the best skimage.measure.CircleModel approximation
+    
+    
+    pupilfit2
+    Use fmin to minimize overlapping between the generated and the template pupil
+    
+    '''    
+    def __init__(self, binary_mask):
+        self._mask = binary_mask.copy()
+        self._params=None
+        self._shape2fit=None
+        
+    def params(self):
+        return self._params
+
+    def fit(self, shape2fit='circle', method='', usecanny=True, **keywords):
+        
+        if shape2fit=='circle':
+            self._shape2fit = measure.CircleModel
+        else:
+            raise Exception('Other shape but circle not implemented yet')
+        
+        if method=='':
+            self._params = self._fit_correlation(shape2fit=shape2fit, **keywords)
+        elif method=='RANSAC':
+            self._params = self._fit_ransac(**keywords)
+        else:
+            raise ValueError('Wrong fitting method specified')
+        
+
+    def _fit_ransac(self, **keywords):
+        
+        img = np.asarray(self._mask.copy(), dtype=float)
+        img[img > 0] = 128
+        
+        edge = img.copy()
+        if keywords.pop('usecanny', True):
+            edge = feature.canny(img, keywords.pop('sigma',3))
+
+        
+        coords = np.column_stack(np.nonzero(edge))
+    
+        model, inliers = measure.ransac(coords, self._shape2fit,
+                                    keywords.pop('min_samples',10), residual_threshold=0.1,
+                                    max_trials=1000)
+        cx, cy, r = model.params
+    
+        if keywords.pop('display',False):
+            print(r"Cx-Cy {:.2f}-{:.2f}, R {:.2f}".format(cx,cy,r))
+            rr, cc = draw.disk((model.params[0], model.params[1]), model.params[2],
+                            shape=img.shape)
+            img[rr, cc] += 512
+            #plt.figure()
+            self._dispnobl(img)
+            
+    
+        return model.params
+    
+    
+    def _fit_correlation(self, display=False, **keywords):
+    
+        img = np.asarray(self._mask.copy(), dtype=int)
+    #  img[img > 0] = 128
+        regions = measure.regionprops(img)
+        bubble = regions[0]
+    
+        y0, x0 = bubble.centroid
+        r = bubble.major_axis_length / 2.
+        showfit= keywords.pop('display',False)
+        if showfit:
+            fign = plt.figure()
+    
+        if keywords['shape2fit']=='circle': 
+            
+            def _cost_disk(params):
+                x0, y0, r = params
+                coords = draw.disk((y0, x0), r, shape=img.shape)
+                template = np.zeros_like(img)
+                template[coords] = 1
+                if showfit:
+                    self._dispnobl(template+img, fign)
+                return -np.sum(template == img)
+        
+            params = optimize.fmin(_cost_disk, (x0, y0, r))
+            
+        else:
+            raise Exception('Other shape but circle not implemented yet')
+        
+       
+        return params
+        
+        
+    def _dispnobl(self,img, fign=None, **kwargs):
+    
+        if fign is not None:
+            plt.figure(fign.number)
+        plt.clf()
+        plt.imshow(img,aspect='auto',**kwargs)
+        plt.colorbar()
+        plt.draw()
+        plt.ion()
+        plt.show()
+        plt.pause(0.001)
+        plt.ioff()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ astropy
 synphot
 pytest
 skycalc-cli
+scikit-image
+scipy

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,9 @@ setup(name=NAME,
                         "astropy",
                         "synphot",
                         "pytest",
-                        "skycalc-cli"
+                        "skycalc-cli",
+                        "scikit-image",
+                        "scipy"
                         ],
       include_package_data=True,
       test_suite='test',

--- a/test/utils/shape_fitter_test.py
+++ b/test/utils/shape_fitter_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import doctest
+import unittest
+import numpy as np
+from arte.utils.shape_fitter import ShapeFitter
+from arte.types.mask import CircularMask,AnnularMask
+
+
+class PupilFitterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.shape= (128, 128)
+        self.radius = 52
+        self.cx = 60.5
+        self.cy = 70.5
+        self.inradius=15
+        self.params2check = [self.cx-0.5, self.cy-0.5, self.radius]
+        self.testMask1= CircularMask(self.shape, 
+                                     maskRadius=self.radius, 
+                                     maskCenter=(self.cx, self.cy))
+        self.testMask2= AnnularMask(self.shape, 
+                                    maskRadius=self.radius, 
+                                    maskCenter=(self.cx, self.cy), 
+                                    inRadius=self.inradius )
+
+    def test_docstring(self):
+        import arte.utils.shape_fitter as pf_module
+        doctest.testmod(pf_module, raise_on_error=True)
+        
+    def test_ransac(self):
+        ff = ShapeFitter(self.testMask1.asTransmissionValue())
+        ff.fit(method='RANSAC')
+        ff2 = ShapeFitter(self.testMask2.asTransmissionValue())
+        ff2.fit(method='RANSAC')
+        self.assertEqual(np.round(self.params2check,1).all(), np.round(ff.params(),1).all())
+        self.assertEqual(np.round(self.params2check,1).all(), np.round(ff2.params(),1).all())
+    
+    def test_correlation(self):
+        ff = ShapeFitter(self.testMask1.asTransmissionValue())
+        ff.fit()
+        ff2 = ShapeFitter(self.testMask2.asTransmissionValue())
+        ff2.fit()
+        self.assertEqual(np.round(self.params2check,1).all(), np.round(ff.params(),1).all())
+        self.assertEqual(np.round(self.params2check,1).all(), np.round(ff2.params(),1).all())
+    
+    def test_exceptions(self):
+    
+        ff = ShapeFitter(self.testMask1.asTransmissionValue())
+    
+        with self.assertRaises(Exception):
+            _ = ff.fit(shape2fit='ellipse')
+    
+        with self.assertRaises(ValueError):
+            _ = ff.fit(method='new')
+
+
+       
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
added new util shape_fitter to fit a circle on a binary mask with RANSAC
(best for circumferences) or fmin (default, for disks, even holed)
new libs requested 