### PR TITLE
Modal recomposer

### DIFF
--- a/arte/types/modal_coefficients.py
+++ b/arte/types/modal_coefficients.py
@@ -1,12 +1,11 @@
 import numpy as np
-from arte.types.zernike_coefficients import ZernikeCoefficients
+from numbers import Number
 
 
-class ModalCoefficients(ZernikeCoefficients):
+class ModalCoefficients():
     FIRST_MODE = 0
 
     def __init__(self, coefficients, counter=0, first_mode=0):
-
         self._coefficients = coefficients
         self._counter = counter
         self.FIRST_MODE = first_mode
@@ -51,3 +50,82 @@ class ModalCoefficients(ZernikeCoefficients):
     def __str__(self):
         return str(self._coefficients)
 
+    def __add__(self, other):
+        if isinstance(other, ModalCoefficients):
+            if len(self._coefficients) < len(other._coefficients):
+                c = other._coefficients.copy()
+                c[:len(self._coefficients)] += self._coefficients
+            else:
+                c = self._coefficients.copy()
+                c[:len(other._coefficients)] += other._coefficients
+            return ModalCoefficients(c)
+        if isinstance(other, Number):
+            return ModalCoefficients(self._coefficients + other)
+        return NotImplemented
+
+    def __radd__(self, other):
+      return self.__add__(other)
+
+    def __iadd__(self, other):
+        if isinstance(other, ModalCoefficients):
+            if len(self._coefficients) < len(other._coefficients):
+                c = other._coefficients.copy()
+                c[:len(self._coefficients)] += self._coefficients
+            else:
+                c = self._coefficients.copy()
+                c[:len(other._coefficients)] += other._coefficients
+            self._coefficients = c
+            return self
+        elif isinstance(other, Number):
+            self._coefficients += other
+            return self
+        return NotImplemented
+
+    def __neg__(self):
+        return ModalCoefficients(-self._coefficients)
+
+    def __pos__(self):
+        return ModalCoefficients(self._coefficients)
+
+    def __abs__(self):
+        return pow(sum(coo**2 for coo in self._coefficients), 0.5)
+
+    def __sub__(self, other):
+        return self + (-other)
+
+    def __rsub__(self, other):
+        return other + (-self)
+
+    def __isub__(self, other):
+        self += -other
+        return self
+
+    def __mul__(self, other):
+        if isinstance(other, Number):
+            return ModalCoefficients(self._coefficients * other)
+        return NotImplemented
+
+    def __rmul__(self, other):
+        return self * other
+
+    def __imul__(self, other):
+        if isinstance(other, Number):
+            self._coefficients *= other
+            return self
+        return NotImplemented
+
+    def __truediv__(self, other):
+        if isinstance(other, Number):
+            return ModalCoefficients(self._coefficients / other)
+        return NotImplemented
+
+    def __rtruediv__(self, other):
+        if isinstance(other, Number):
+            return ModalCoefficients(other / self._coefficients)
+        return NotImplemented
+
+    def __itruediv__(self, other):
+        if isinstance(other, Number):
+            self._coefficients /= other
+            return self
+        return NotImplemented

--- a/arte/types/zernike_coefficients.py
+++ b/arte/types/zernike_coefficients.py
@@ -1,41 +1,22 @@
 import numpy as np
-from numbers import Number
+from arte.types.modal_coefficients import ModalCoefficients
 
-class ZernikeCoefficients(object):
+
+class ZernikeCoefficients(ModalCoefficients):
     FIRST_ZERNIKE_MODE = 2
 
     def __init__(self, coefficients, counter=0):
-        self._coefficients = coefficients
-        self._counter = counter
+        super().__init__(coefficients, counter, first_mode=self.FIRST_ZERNIKE_MODE)
 
     def zernikeIndexes(self):
-        return np.arange(self.FIRST_ZERNIKE_MODE,
-                         self.FIRST_ZERNIKE_MODE + self.numberOfModes())
-
-    def numberOfModes(self):
-        return len(self._coefficients)
+        return self.modeIndexes()
 
     def getZ(self, zernikeIndexes):
-        return self.toNumpyArray()[np.array(zernikeIndexes) - 
-                                   self.FIRST_ZERNIKE_MODE]
-
-    def toDictionary(self):
-        keys = self.zernikeIndexes()
-        values = self._coefficients
-        return dict(list(zip(keys, values)))
-
-    def toNumpyArray(self):
-        return self._coefficients
+        return self.getM(zernikeIndexes)
 
     @staticmethod
     def fromNumpyArray(coefficientsAsNumpyArray, counter=0):
         return ZernikeCoefficients(np.array(coefficientsAsNumpyArray), counter)
-
-    def counter(self):
-        return self._counter
-
-    def setCounter(self, counter):
-        self._counter = counter
 
     def __eq__(self, o):
         if self._counter != o._counter:
@@ -49,83 +30,3 @@ class ZernikeCoefficients(object):
 
     def __str__(self):
         return str(self._coefficients)
-
-    def __add__(self, other):
-        if isinstance(other, ZernikeCoefficients):
-            if len(self._coefficients) < len(other._coefficients):
-                c = other._coefficients.copy()
-                c[:len(self._coefficients)] += self._coefficients
-            else:
-                c = self._coefficients.copy()
-                c[:len(other._coefficients)] += other._coefficients
-            return ZernikeCoefficients(c)
-        if isinstance(other, Number):
-            return ZernikeCoefficients(self._coefficients + other)
-        return NotImplemented
-
-    def __radd__(self, other):
-      return self.__add__(other)
-
-    def __iadd__(self, other):
-        if isinstance(other, ZernikeCoefficients):
-            if len(self._coefficients) < len(other._coefficients):
-                c = other._coefficients.copy()
-                c[:len(self._coefficients)] += self._coefficients
-            else:
-                c = self._coefficients.copy()
-                c[:len(other._coefficients)] += other._coefficients
-            self._coefficients = c
-            return self
-        elif isinstance(other, Number):
-            self._coefficients += other
-            return self
-        return NotImplemented
-
-    def __neg__(self):
-        return ZernikeCoefficients(-self._coefficients)
-
-    def __pos__(self):
-        return ZernikeCoefficients(self._coefficients)
-
-    def __abs__(self):
-        return pow(sum(coo**2 for coo in self._coefficients), 0.5)
-
-    def __sub__(self, other):
-        return self + (-other)
-
-    def __rsub__(self, other):
-        return other + (-self)
-
-    def __isub__(self, other):
-        self += -other
-        return self
-
-    def __mul__(self, other):
-        if isinstance(other, Number):
-            return ZernikeCoefficients(self._coefficients * other)
-        return NotImplemented
-
-    def __rmul__(self, other):
-        return self * other
-
-    def __imul__(self, other):
-        if isinstance(other, Number):
-            self._coefficients *= other
-            return self
-        return NotImplemented
-
-    def __truediv__(self, other):
-        if isinstance(other, Number):
-            return ZernikeCoefficients(self._coefficients / other)
-        return NotImplemented
-
-    def __rtruediv__(self, other):
-        if isinstance(other, Number):
-            return ZernikeCoefficients(other / self._coefficients)
-        return NotImplemented
-
-    def __itruediv__(self, other):
-        if isinstance(other, Number):
-            self._coefficients /= other
-            return self
-        return NotImplemented

--- a/arte/utils/base_modal_decomposer.py
+++ b/arte/utils/base_modal_decomposer.py
@@ -15,14 +15,14 @@ class BaseModalDecomposer(abc.ABC):
 
     def __init__(self, n_modes=None):
         self.nModes = n_modes
-        self.lastModesGenerator = None
-        self.lastIM = None
-        self.lastRank = None
-        self.lastReconstructor = None
-        self.lastMask = None
+        self._lastModesGenerator = None
+        self._lastIM = None
+        self._lastRank = None
+        self._lastReconstructor = None
+        self._lastMask = None
 
     @abc.abstractmethod
-    def generator(self, nModes, circular_mask, user_mask, **kwargs):
+    def _generator(self, nModes, circular_mask, user_mask, **kwargs):
         '''Override to return a modal generator instance'''
 
     def _numpy2coefficients(self, coeff_array):
@@ -31,7 +31,7 @@ class BaseModalDecomposer(abc.ABC):
         return ModalCoefficients(coeff_array)
 
     def getLastRank(self):
-        return self.lastRank
+        return self._lastRank
 
     def _wavefront_interaction_matrix(self, modes_generator, modesIdx, user_mask, dtype):
         wf = modes_generator.getModesDict(modesIdx)
@@ -71,18 +71,18 @@ class BaseModalDecomposer(abc.ABC):
 
         self._assert_types(circular_mask, user_mask)
 
-        modes_generator = self.generator(
+        modes_generator = self._generator(
             nModes, circular_mask, user_mask, **kwargs)
         if start_mode is None:
             first_mode = modes_generator.first_mode()
         else:
             first_mode = start_mode
 
-        self.lastModesGenerator = modes_generator
+        self._lastModesGenerator = modes_generator
 
         modesIdx = list(range(first_mode, first_mode + nModes))
         im = im_func(modes_generator, modesIdx, user_mask, dtype)
-        self.lastIM = im
+        self._lastIM = im
         return im
 
     def _syntheticReconstructor(self, im_func, nModes,
@@ -174,9 +174,9 @@ class BaseModalDecomposer(abc.ABC):
             np.dot(wavefrontInMaskVectorNoPiston, reconstructor)
         )
         # Remember last used values
-        self.lastRank = rank
-        self.lastMask = user_mask
-        self.lastReconstructor = reconstructor
+        self._lastRank = rank
+        self._lastMask = user_mask
+        self._lastReconstructor = reconstructor
         return result
 
     def measureModalCoefficientsFromSlopes(self, slopes, circular_mask,
@@ -198,9 +198,9 @@ class BaseModalDecomposer(abc.ABC):
 
         result = self._numpy2coefficients(np.dot(slopesInMaskVector, reconstructor))
         # Remember last used values
-        self.lastRank = rank
-        self.lastMask = user_mask
-        self.lastReconstructor = reconstructor
+        self._lastRank = rank
+        self._lastMask = user_mask
+        self._lastReconstructor = reconstructor
         return result
 
     def _assert_types(self, circular_mask, user_mask=None, wavefront=None,

--- a/arte/utils/karhunen_loeve_decomposer.py
+++ b/arte/utils/karhunen_loeve_decomposer.py
@@ -18,7 +18,7 @@ class KarhunenLoeveModalDecomposer(BaseModalDecomposer):
     def __init__(self, n_modes=None):
         super().__init__(n_modes)
 
-    def generator(self, nModes, circular_mask, user_mask, **kwargs):
+    def _generator(self, nModes, circular_mask, user_mask, **kwargs):
         zz = ZernikeGenerator(circular_mask)
         zbase = np.rollaxis(
             np.ma.masked_array([zz.getZernike(n) for n in range(2, self.nModes + 2)]),

--- a/arte/utils/radial_basis_decomposer.py
+++ b/arte/utils/radial_basis_decomposer.py
@@ -26,7 +26,7 @@ class RadialBasisModalDecomposer(BaseModalDecomposer):
         self.coordinates_list = coordinates_list
         super().__init__(n_modes = len(coordinates_list))
 
-    def generator(self, nModes, circular_mask, user_mask, rbfFunction=None, **kwargs):
+    def _generator(self, nModes, circular_mask, user_mask, rbfFunction=None, **kwargs):
         rbf = RBFGenerator(circular_mask, self.coordinates_list, rbfFunction=rbfFunction)
         rbf.generate()
         return rbf

--- a/arte/utils/zernike_decomposer.py
+++ b/arte/utils/zernike_decomposer.py
@@ -20,7 +20,7 @@ class ZernikeModalDecomposer(BaseModalDecomposer):
             n_modes = n_zernike_modes
         super().__init__(n_modes)
 
-    def generator(self, nModes, circular_mask, user_mask, **kwargs):
+    def _generator(self, nModes, circular_mask, user_mask, **kwargs):
         return ZernikeGenerator(circular_mask)
 
     def _numpy2coefficients(self, coeff_array):

--- a/test/utils/modal_decomposer_test.py
+++ b/test/utils/modal_decomposer_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+from arte.utils.zernike_decomposer import ZernikeModalDecomposer
 from arte.utils.zernike_generator import ZernikeGenerator
 from arte.types.mask import CircularMask, BaseMask
 from arte.utils.karhunen_loeve_decomposer import KarhunenLoeveModalDecomposer
@@ -360,6 +361,20 @@ class ModalDecomposerTest(unittest.TestCase):
         mask = CircularMask((200, 200), 90, [100, 100])
         md.measureZernikeCoefficientsFromSlopes(
             slopes, mask, BaseMask(slopeMask.mask()))
+
+    def testRecomposeWavefrontFromZernikeCoefficients(self):
+        zern_coeff = ZernikeCoefficients.fromNumpyArray([0, 1, 0])
+        zmd = ZernikeModalDecomposer(n_modes=10)
+        radius = 4
+        mask = CircularMask((2 * radius, 2 * radius), radius)
+        wf = zmd.recomposeWavefrontFromModalCoefficients(zern_coeff, mask)
+        self.assertIsInstance(wf, Wavefront)
+        self.assertEqual(wf.toNumpyArray().shape, (2*radius, 2*radius))
+        wanted = 2*(radius-0.5)/radius
+        np.testing.assert_allclose(
+            wf.toNumpyArray().max(), wanted)
+        np.testing.assert_allclose(wf.toNumpyArray().min(), -wanted)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a recomposeWavefrontFromModalCoefficients method to the ModalDecomposer that creates the wavefront map corresponding to a given set of modal coefficients. It uses MVM and the interaction matrix to speed up computation