### PR TITLE
Timeseries chainable

### DIFF
--- a/arte/time_series/multi_time_series.py
+++ b/arte/time_series/multi_time_series.py
@@ -12,13 +12,34 @@ class MultiTimeSeries(TimeSeries):
     After being initialized with a list of
     :class:`~arte.time_series.time_series.TimeSeries` objects, which can
     have different ensemble sizes and length, it behaves as if all the data
-    was part of a single ensemble. Operations that make calculations
-    time-wise (like 
-    :meth:`~arte.time_series.time_series.TimeSeries.time_std()`) work in any
-    case. The ensemble-wise ones
-    (like :meth:`~arte.time_series.time_series.TimeSeries.ensemble_std()`)
-    only work if deltaTime is the same
-    across all series, and raise an Exception otherwise.
+    was part of a single ensemble. 
+    
+    **Time operations** (like :attr:`time_mean`, :attr:`time_std`) work in any case.
+    
+    **Ensemble operations** (like :attr:`ensemble_mean`, :attr:`ensemble_std`) 
+    only work if all series have the same sampling rate (``delta_time``), 
+    and raise an Exception otherwise. Use :meth:`is_homogeneous` to check 
+    compatibility before calling ensemble operations.
+    
+    Examples
+    --------
+    >>> # Create multi-series with compatible sampling
+    >>> multi = MultiTimeSeries(series1_1khz, series2_1khz)
+    >>> multi.is_homogeneous()  # True - same sampling rates
+    True
+    >>> mean = multi.ensemble_mean.value  # Works!
+    >>> 
+    >>> # Incompatible sampling raises exception
+    >>> multi2 = MultiTimeSeries(series_1khz, series_500hz)
+    >>> multi2.ensemble_mean  # Raises Exception - incompatible rates
+    >>> 
+    >>> # Time operations always work
+    >>> time_avg = multi2.time_mean.value  # Always works
+    
+    Notes
+    -----
+    Chainable API: ensemble operations return TimeSeries objects that can
+    be chained with time operations and vice versa.
     '''
     def __init__(self, *args):
         super().__init__()
@@ -102,31 +123,289 @@ class MultiTimeSeries(TimeSeries):
 
         return dt
 
+    # Legacy methods (deprecated - use properties instead)
+    
     @modify_help(arg_str='[time_idx]')
-    def ensemble_average(self, *args, times=None, **kwargs):
-        ''' Average across series at each sampling time '''
+    def get_ensemble_average(self, *args, times=None, **kwargs):
+        '''
+        Average across series at each sampling time (legacy method).
+        
+        .. deprecated::
+           Use the `ensemble_mean` property instead. This method will be removed in a future version.
+        
+        Returns
+        -------
+        ndarray
+            Mean values (not chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates (not homogeneous)
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_average() is deprecated. Use the 'ensemble_mean' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         if self.is_homogeneous(*args, **kwargs):
             self._impersonateDeltaTime(*args, **kwargs) 
-            return super().ensemble_average(*args, times=times, **kwargs)
+            return super().get_ensemble_average(*args, times=times, **kwargs)
         else:
             raise Exception('Data series cannot be combined')
 
     @modify_help(arg_str='[time_idx]')
-    def ensemble_std(self, *args, times=None, **kwargs):
-        ''' Standard deviation across series at each sampling time '''
+    def get_ensemble_std(self, *args, times=None, **kwargs):
+        '''
+        Standard deviation across series at each sampling time (legacy method).
+        
+        .. deprecated::
+           Use the `ensemble_std` property instead. This method will be removed in a future version.
+        
+        Returns
+        -------
+        ndarray
+            Std values (not chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates (not homogeneous)
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_std() is deprecated. Use the 'ensemble_std' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         if self.is_homogeneous(*args, **kwargs):
             self._impersonateDeltaTime(*args, **kwargs) 
-            return super().ensemble_std(*args, times=times, **kwargs)
+            return super().get_ensemble_std(*args, times=times, **kwargs)
         else:
             raise Exception('Data series cannot be combined')
 
     @modify_help(arg_str='[time_idx]')
-    def ensemble_median(self, *args, times=None, **kwargs):
-        ''' Standard deviation across series at each sampling time '''
+    def get_ensemble_median(self, *args, times=None, **kwargs):
+        '''
+        Median across series at each sampling time (legacy method).
+        
+        .. deprecated::
+           Use the `ensemble_median` property instead. This method will be removed in a future version.
+        
+        Returns
+        -------
+        ndarray
+            Median values (not chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates (not homogeneous)
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_median() is deprecated. Use the 'ensemble_median' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         if self.is_homogeneous(*args, **kwargs):
             self._impersonateDeltaTime(*args, **kwargs) 
-            return super().ensemble_median(*args, times=times, **kwargs)
+            return super().get_ensemble_median(*args, times=times, **kwargs)
         else:
             raise Exception('Data series cannot be combined')
+    
+    # Chainable properties (override base class to add homogeneity check)
+    
+    @property
+    def ensemble_mean(self):
+        """
+        Mean over ensemble dimensions (chainable property).
+        
+        Computes the mean across all series at each time step.
+        Requires all series to have compatible sampling rates.
+        
+        Returns
+        -------
+        TimeSeries
+            Mean across ensemble at each time step (chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates.
+            Use :meth:`is_homogeneous` to check compatibility first.
+        
+        Examples
+        --------
+        >>> # Check compatibility before using
+        >>> if multi.is_homogeneous():
+        ...     mean = multi.ensemble_mean.value
+        >>> 
+        >>> # Chain with time operations
+        >>> overall_mean = multi.ensemble_mean.time_mean.value
+        
+        See Also
+        --------
+        is_homogeneous : Check if series have compatible sampling rates
+        ensemble_std : Standard deviation across ensemble
+        ensemble_median : Median across ensemble
+        """
+        if not self.is_homogeneous():
+            raise Exception('Data series cannot be combined - incompatible sampling rates. '
+                          'Use is_homogeneous() to check compatibility.')
+        self._impersonateDeltaTime()
+        return super().ensemble_mean
+    
+    @property
+    def ensemble_std(self):
+        """
+        Standard deviation over ensemble dimensions (chainable property).
+        
+        Computes the std across all series at each time step.
+        Requires all series to have compatible sampling rates.
+        
+        Returns
+        -------
+        TimeSeries
+            Std across ensemble at each time step (chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates.
+            Use :meth:`is_homogeneous` to check compatibility first.
+        
+        Examples
+        --------
+        >>> if multi.is_homogeneous():
+        ...     std = multi.ensemble_std.value
+        >>> 
+        >>> # Chain with time operations
+        >>> mean_std = multi.ensemble_std.time_mean.value
+        
+        See Also
+        --------
+        is_homogeneous : Check if series have compatible sampling rates
+        ensemble_mean : Mean across ensemble
+        """
+        if not self.is_homogeneous():
+            raise Exception('Data series cannot be combined - incompatible sampling rates. '
+                          'Use is_homogeneous() to check compatibility.')
+        self._impersonateDeltaTime()
+        return super().ensemble_std
+    
+    @property
+    def ensemble_median(self):
+        """
+        Median over ensemble dimensions (chainable property).
+        
+        Computes the median across all series at each time step.
+        Requires all series to have compatible sampling rates.
+        
+        Returns
+        -------
+        TimeSeries
+            Median across ensemble at each time step (chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates.
+            Use :meth:`is_homogeneous` to check compatibility first.
+        
+        Examples
+        --------
+        >>> if multi.is_homogeneous():
+        ...     median = multi.ensemble_median.value
+        >>> 
+        >>> # Chain with time operations
+        >>> median_avg = multi.ensemble_median.time_mean.value
+        
+        See Also
+        --------
+        is_homogeneous : Check if series have compatible sampling rates
+        ensemble_mean : Mean across ensemble
+        """
+        if not self.is_homogeneous():
+            raise Exception('Data series cannot be combined - incompatible sampling rates. '
+                          'Use is_homogeneous() to check compatibility.')
+        self._impersonateDeltaTime()
+        return super().ensemble_median
+    
+    @property
+    def ensemble_rms(self):
+        """
+        RMS over ensemble dimensions (chainable property).
+        
+        Computes the RMS across all series at each time step.
+        Requires all series to have compatible sampling rates.
+        
+        Returns
+        -------
+        TimeSeries
+            RMS across ensemble at each time step (chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates.
+            Use :meth:`is_homogeneous` to check compatibility first.
+        
+        Examples
+        --------
+        >>> if multi.is_homogeneous():
+        ...     rms = multi.ensemble_rms.value
+        >>> 
+        >>> # Chain with time operations
+        >>> mean_rms = multi.ensemble_rms.time_mean.value
+        
+        See Also
+        --------
+        is_homogeneous : Check if series have compatible sampling rates
+        ensemble_mean : Mean across ensemble
+        """
+        if not self.is_homogeneous():
+            raise Exception('Data series cannot be combined - incompatible sampling rates. '
+                          'Use is_homogeneous() to check compatibility.')
+        self._impersonateDeltaTime()
+        return super().ensemble_rms
+    
+    @property
+    def ensemble_ptp(self):
+        """
+        Peak-to-peak over ensemble dimensions (chainable property).
+        
+        Computes the peak-to-peak range across all series at each time step.
+        Requires all series to have compatible sampling rates.
+        
+        Returns
+        -------
+        TimeSeries
+            Peak-to-peak across ensemble at each time step (chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates.
+            Use :meth:`is_homogeneous` to check compatibility first.
+        
+        Examples
+        --------
+        >>> if multi.is_homogeneous():
+        ...     ptp = multi.ensemble_ptp.value
+        >>> 
+        >>> # Chain with time operations
+        >>> mean_ptp = multi.ensemble_ptp.time_mean.value
+        
+        See Also
+        --------
+        is_homogeneous : Check if series have compatible sampling rates
+        """
+        if not self.is_homogeneous():
+            raise Exception('Data series cannot be combined - incompatible sampling rates. '
+                          'Use is_homogeneous() to check compatibility.')
+        self._impersonateDeltaTime()
+        return super().ensemble_ptp
 
 # ___oOo___

--- a/arte/time_series/multi_time_series.py
+++ b/arte/time_series/multi_time_series.py
@@ -214,6 +214,66 @@ class MultiTimeSeries(TimeSeries):
             return super().get_ensemble_median(*args, times=times, **kwargs)
         else:
             raise Exception('Data series cannot be combined')
+
+    @modify_help(arg_str='[time_idx]')
+    def get_ensemble_rms(self, *args, times=None, **kwargs):
+        '''
+        Root-Mean-Square across series at each sampling time (legacy method).
+        
+        .. deprecated::
+           Use the `ensemble_rms` property instead. This method will be removed in a future version.
+        
+        Returns
+        -------
+        ndarray
+            RMS values (not chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates (not homogeneous)
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_rms() is deprecated. Use the 'ensemble_rms' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        if self.is_homogeneous(*args, **kwargs):
+            self._impersonateDeltaTime(*args, **kwargs) 
+            return super().get_ensemble_rms(*args, times=times, **kwargs)
+        else:
+            raise Exception('Data series cannot be combined')
+
+    @modify_help(arg_str='[time_idx]')
+    def get_ensemble_ptp(self, *args, times=None, **kwargs):
+        '''
+        Peak-to-peak (max - min) across series at each sampling time (legacy method).
+        
+        .. deprecated::
+           Use the `ensemble_ptp` property instead. This method will be removed in a future version.
+        
+        Returns
+        -------
+        ndarray
+            Peak-to-peak values (not chainable)
+        
+        Raises
+        ------
+        Exception
+            If series have incompatible sampling rates (not homogeneous)
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_ptp() is deprecated. Use the 'ensemble_ptp' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        if self.is_homogeneous(*args, **kwargs):
+            self._impersonateDeltaTime(*args, **kwargs) 
+            return super().get_ensemble_ptp(*args, times=times, **kwargs)
+        else:
+            raise Exception('Data series cannot be combined')
     
     # Chainable properties (override base class to add homogeneity check)
     

--- a/arte/time_series/multi_time_series.py
+++ b/arte/time_series/multi_time_series.py
@@ -81,7 +81,7 @@ class MultiTimeSeries(TimeSeries):
         Notes
         -----
         This check is necessary before calling ensemble-wise operations
-        like :meth:`ensemble_average` or :meth:`ensemble_std`, which
+        like :attr:`ensemble_mean` or :attr:`ensemble_std`, which
         require uniform time sampling across all series.
         
         Examples

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -677,11 +677,20 @@ class TimeSeries(metaclass=abc.ABCMeta):
             def _get_time_vector(self):
                 # Time vector reflects filtering
                 if self._filter_times is not None:
-                    parent_time = self._parent.get_time_vector()
-                    parent_data = self._parent._get_not_indexed_data()
+                    # Validate times parameter (same as get_data)
+                    if not isinstance(self._filter_times, collections.abc.Sequence) or len(self._filter_times) != 2:
+                        raise TimeSeriesException('Times keywords must be a sequence of two elements: [start, stop]')
                     
-                    # Apply time filtering logic
+                    parent_time = self._parent.get_time_vector()
+                    
+                    # Apply time filtering logic with unit conversion (same as get_data)
                     start, stop = self._filter_times
+                    if isinstance(parent_time, u.Quantity):
+                        if start is not None:
+                            start = make_sure_its_a(parent_time.unit, start)
+                        if stop is not None:
+                            stop = make_sure_its_a(parent_time.unit, stop)
+                    
                     idxs = np.ones(len(parent_time), dtype=bool)
                     if start is not None:
                         idxs = np.logical_and(idxs, parent_time >= start)

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -785,8 +785,8 @@ class TimeSeries(metaclass=abc.ABCMeta):
         
         # Ensure data has time axis with size 1
         if data.ndim == 0:
-            # Scalar → (1,)
-            reduced_data = np.array([data])
+            # Scalar → (1,) - use atleast_1d to preserve Quantity
+            reduced_data = np.atleast_1d(data)
         elif data.shape[0] != 1:
             # Add time axis: (ensemble,) → (1, ensemble...)
             reduced_data = np.expand_dims(data, axis=0)
@@ -826,6 +826,28 @@ class TimeSeries(metaclass=abc.ABCMeta):
                 return 0 if not isinstance(self._parent.delta_time, u.Quantity) else 0 * self._parent.delta_time.unit
         
         return TemporalReducedTimeSeries()
+    
+    @property
+    def shape(self):
+        """
+        Shape of the underlying data array.
+        
+        Returns the shape tuple of the TimeSeries data, similar to numpy arrays.
+        This provides convenient access without requiring explicit conversion.
+        
+        Returns
+        -------
+        tuple of int
+            Shape of the data array (time, ensemble...)
+        
+        Examples
+        --------
+        >>> ts.shape
+        (1000, 10)  # 1000 time steps, 10 modes
+        >>> ts.ensemble_rms.shape
+        (1000,)  # Collapsed to time dimension only
+        """
+        return self._get_not_indexed_data().shape
     
     @property
     def value(self):

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -97,6 +97,73 @@ class TimeSeries(metaclass=abc.ABCMeta):
         self._window = None
         self._axis_handler = AxisHandler(axes)
 
+    def __array__(self, dtype=None, copy=None):
+        """
+        Numpy compatibility protocol (numpy 2.0+ compatible).
+        
+        Enables using TimeSeries directly in numpy operations and matplotlib:
+        - plt.plot(time, ts) - automatic conversion
+        - np.mean(ts) - works directly
+        
+        Parameters
+        ----------
+        dtype : numpy dtype, optional
+            Desired dtype for the array (numpy 2.0+)
+        copy : bool, optional
+            Whether to copy the data (numpy 2.0+)
+        
+        Returns
+        -------
+        ndarray
+            Underlying data array
+        
+        Examples
+        --------
+        >>> ts = MyTimeSeries(data)
+        >>> rms = ts.ensemble_rms_property  # Returns TimeSeries
+        >>> plt.plot(rms)  # Works! __array__() called automatically
+        >>> mean_rms = np.mean(rms)  # Works!
+        """
+        arr = self._get_not_indexed_data()
+        if dtype is not None:
+            arr = arr.astype(dtype)
+        if copy:
+            arr = arr.copy()
+        return arr
+    
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """
+        Support numpy universal functions on TimeSeries.
+        
+        Enables operations like: np.sin(ts), np.sqrt(ts), ts * 2
+        
+        Parameters
+        ----------
+        ufunc : numpy ufunc
+            The universal function being applied
+        method : str
+            The ufunc method ('__call__', 'reduce', etc.)
+        *inputs : tuple
+            Input arrays/objects
+        **kwargs : dict
+            Additional ufunc arguments
+        
+        Returns
+        -------
+        ndarray or scalar
+            Result of the ufunc operation
+        """
+        # Convert TimeSeries inputs to arrays
+        arrays = []
+        for inp in inputs:
+            if isinstance(inp, TimeSeries):
+                arrays.append(inp.__array__())
+            else:
+                arrays.append(inp)
+        
+        # Apply ufunc and return result (not wrapped in TimeSeries)
+        return getattr(ufunc, method)(*arrays, **kwargs)
+
     @abc.abstractmethod
     def _get_not_indexed_data(self):
         pass
@@ -266,16 +333,36 @@ class TimeSeries(metaclass=abc.ABCMeta):
         return np.median(data, axis=0)
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def time_std(self, *args, times=None, **kwargs):
-        '''Standard deviation over time for each series'''
+    def get_time_std(self, *args, times=None, **kwargs):
+        '''Standard deviation over time for each series
+        
+        .. deprecated:: 
+           Use the `time_std` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_time_std() is deprecated. Use the 'time_std' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.std(data, axis=0)
         return np.std(data, axis=0)
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def time_average(self, *args, times=None, **kwargs):
-        '''Average value over time for each series'''
+    def get_time_average(self, *args, times=None, **kwargs):
+        '''Average value over time for each series
+        
+        .. deprecated:: 
+           Use the `time_mean` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_time_average() is deprecated. Use the 'time_mean' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.mean(data, axis=0)
@@ -323,8 +410,27 @@ class TimeSeries(metaclass=abc.ABCMeta):
         return np.median(data, axis=self._data_sample_axes(data))
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def ensemble_rms(self, *args, times=None, **kwargs):
-        '''Root-Mean-Square across series at each sampling time'''
+    def get_ensemble_rms(self, *args, times=None, **kwargs):
+        '''
+        Root-Mean-Square across series at each sampling time (legacy method).
+        
+        .. deprecated:: 
+            Use the chainable property :attr:`ensemble_rms` for fluent API:
+            ``ts.ensemble_rms`` or ``ts.filter(modes=[2,3,4]).ensemble_rms``
+            This method will be removed in a future version.
+        
+        Returns
+        -------
+        ndarray
+            RMS values (not chainable)
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_rms() is deprecated. Use the chainable property 'ensemble_rms' instead: "
+            "ts.ensemble_rms or ts.filter(modes=[2,3,4]).ensemble_rms",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.sqrt(np.ma.mean(np.abs(data)**2, axis=self._data_sample_axes(data)))
@@ -337,6 +443,483 @@ class TimeSeries(metaclass=abc.ABCMeta):
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.ptp(data, axis=self._data_sample_axes(data))
         return np.ptp(data, axis=self._data_sample_axes(data))
+
+    # --- Chainable (Fluent) API ---
+    # Upstream filtering methods for fluent API
+    
+    def filter(self, *args, **kwargs):
+        """
+        Create filtered TimeSeries by applying ensemble and/or time selection.
+        
+        Accepts same arguments as get_data(), creating a new TimeSeries
+        with pre-filtered data for fluent chaining. Works with any Indexer
+        implementation (ModeIndexer, RowColIndexer, DefaultIndexer, custom).
+        
+        Parameters
+        ----------
+        *args, **kwargs
+            Passed to get_index_of() for ensemble filtering.
+            Common kwargs depend on the Indexer:
+            - modes= : for ModeIndexer (mode numbers)
+            - elements= : for DefaultIndexer (element indices)
+            - rows=, cols= : for RowColIndexer (spatial coordinates)
+            - coord=, axis= : for interleaved/sequential xy layouts
+        times : sequence of 2 elements, optional
+            Time range [start, stop] for temporal filtering.
+            Can contain None for one-sided filtering.
+        
+        Returns
+        -------
+        TimeSeries
+            New TimeSeries with filtered data (chainable)
+        
+        Examples
+        --------
+        >>> # Modal selection (uses ModeIndexer in derived classes)
+        >>> ts.filter(modes=[2, 3, 4]).ensemble_rms.time_mean
+        >>> 
+        >>> # Time + modal selection
+        >>> ts.filter(modes=[2, 3, 4], times=[0.5, 1.0]).ensemble_rms.time_mean
+        >>> 
+        >>> # Element selection (DefaultIndexer)
+        >>> ts.filter(elements=[0, 2, 4, 6]).time_std
+        >>> 
+        >>> # Row/col selection (RowColIndexer for 2D data)
+        >>> ts.filter(rows=slice(0, 10), cols=[5, 10]).ensemble_rms
+        >>> 
+        >>> # Chainable (filters are accumulated)
+        >>> ts.filter(modes=[2, 3, 4]).filter(times=[0.5, 1.0]).ensemble_rms.time_mean
+        >>> 
+        >>> # Custom indexer kwargs work automatically
+        >>> ts.filter(coord='x').time_mean  # for interleaved xy data
+        """
+        return self._create_filtered_series(*args, **kwargs)
+    
+    def with_times(self, times):
+        """
+        Filter to specific time interval (convenience alias for filter(times=...)).
+        
+        Returns a new chainable TimeSeries containing only data within
+        the specified time range [start, stop].
+        
+        Note: This is an alias for filter(times=...). For filtering by both
+        time and ensemble elements, use filter() directly.
+        
+        Parameters
+        ----------
+        times : sequence of 2 elements
+            Time range [start, stop] (can contain None for one-sided filtering)
+        
+        Returns
+        -------
+        TimeSeries
+            Time-filtered TimeSeries (chainable)
+        
+        Examples
+        --------
+        >>> # Filter time range and compute statistics
+        >>> ts.with_times([1, 2]).ensemble_rms.time_mean
+        >>> 
+        >>> # Chain with filter() for ensemble selection
+        >>> ts.filter(modes=[2, 3, 4]).with_times([1, 2]).ensemble_rms
+        >>> 
+        >>> # Equivalent using filter() directly (preferred)
+        >>> ts.filter(modes=[2, 3, 4], times=[1, 2]).ensemble_rms
+        """
+        return self.filter(times=times)
+    
+    def _create_filtered_series(self, *args, **kwargs):
+        """
+        Create filtered view of this TimeSeries.
+        
+        Returns a new TimeSeries that lazily applies filtering when data
+        is accessed. The filtered series supports further chaining.
+        
+        Parameters
+        ----------
+        *args
+            Positional arguments passed to get_index_of()
+        **kwargs
+            Keyword arguments for filtering:
+            - times : time range [start, stop]
+            - Other kwargs passed to get_index_of() (modes=, elements=, rows=, cols=, etc.)
+        
+        Returns
+        -------
+        TimeSeries
+            Filtered TimeSeries (chainable)
+        """
+        parent_ts = self
+        
+        # Extract times separately (handled specially by get_data)
+        filter_times = kwargs.pop('times', None)
+        filter_args = args
+        filter_kwargs = kwargs
+        
+        class FilteredTimeSeries(TimeSeries):
+            def __init__(self):
+                super().__init__()
+                self._parent = parent_ts
+                self._filter_args = filter_args
+                self._filter_kwargs = filter_kwargs
+                self._filter_times = filter_times
+            
+            def _get_not_indexed_data(self):
+                # Apply parent's filtering: delegate all to get_data()
+                return self._parent.get_data(
+                    *self._filter_args,
+                    times=self._filter_times,
+                    **self._filter_kwargs
+                )
+            
+            def get_index_of(self, *args, **kwargs):
+                # Delegate to parent's indexing
+                return self._parent.get_index_of(*args, **kwargs)
+            
+            def _create_filtered_series(self, *args, **kwargs):
+                # Support chaining: accumulate filters
+                # Merge new filters with existing ones
+                new_times = kwargs.pop('times', None)
+                if new_times is None:
+                    new_times = self._filter_times
+                
+                # Merge kwargs (new ones override existing)
+                merged_kwargs = {**self._filter_kwargs, **kwargs}
+                
+                # For args, we can't easily merge, so new args override
+                merged_args = args if args else self._filter_args
+                
+                return self._parent._create_filtered_series(
+                    *merged_args,
+                    times=new_times,
+                    **merged_kwargs
+                )
+            
+            @cache
+            def _get_time_vector(self):
+                # Time vector reflects filtering
+                if self._filter_times is not None:
+                    parent_time = self._parent.get_time_vector()
+                    parent_data = self._parent._get_not_indexed_data()
+                    
+                    # Apply time filtering logic
+                    start, stop = self._filter_times
+                    idxs = np.ones(len(parent_time), dtype=bool)
+                    if start is not None:
+                        idxs = np.logical_and(idxs, parent_time >= start)
+                    if stop is not None:
+                        idxs = np.logical_and(idxs, parent_time < stop)
+                    
+                    return parent_time[idxs]
+                else:
+                    return self._parent.get_time_vector()
+            
+            @cached_property
+            def delta_time(self):
+                return self._parent.delta_time
+        
+        return FilteredTimeSeries()
+    
+    # Chainable operations (properties return TimeSeries)
+    
+    def _create_reduced_series(self, data, operation_name='reduced'):
+        """
+        Create new TimeSeries after reduction operation.
+        
+        Helper for chainable operations that reduce dimensions.
+        Preserves time-related metadata in the new series.
+        
+        Parameters
+        ----------
+        data : ndarray
+            Reduced data (e.g., 1D after ensemble aggregation)
+        operation_name : str, optional
+            Name of operation for tracking/debugging
+        
+        Returns
+        -------
+        TimeSeries
+            New TimeSeries instance wrapping the reduced data (chainable)
+        
+        Notes
+        -----
+        This creates a minimal TimeSeries subclass that wraps the reduced array.
+        Time axis is preserved (axis 0), allowing further temporal operations.
+        """
+        # Create anonymous subclass with the reduced data
+        parent_ts = self
+        
+        class ReducedTimeSeries(TimeSeries):
+            def __init__(self):
+                super().__init__()
+                self._reduced_data = data
+                self._parent = parent_ts
+                self._operation = operation_name
+            
+            def _get_not_indexed_data(self):
+                return self._reduced_data
+            
+            def get_index_of(self, *args, **kwargs):
+                # Reduced series has no ensemble indexing
+                return None
+            
+            def __getitem__(self, key):
+                """Support numpy-style indexing"""
+                return self._reduced_data[key]
+            
+            @cache
+            def _get_time_vector(self):
+                # Inherit time vector from parent
+                return self._parent.get_time_vector()
+            
+            @cached_property
+            def delta_time(self):
+                # Inherit delta_time from parent
+                return self._parent.delta_time
+        
+        return ReducedTimeSeries()
+    
+    def _create_temporal_reduced_series(self, data, operation_name='time_reduced'):
+        """
+        Create TimeSeries after temporal reduction operation.
+        
+        Used for operations that collapse the time dimension (e.g., time_mean, time_std).
+        Returns a TimeSeries with time_size=1, using mean time as the single timestamp.
+        
+        Parameters
+        ----------
+        data : ndarray
+            Temporally reduced data (no time axis, or time_size=1)
+        operation_name : str, optional
+            Name of operation for tracking/debugging
+        
+        Returns
+        -------
+        TimeSeries
+            New TimeSeries with shape (1, ...ensemble_shape...) (chainable)
+        
+        Notes
+        -----
+        The time_vector for the reduced series contains a single element:
+        the mean time of the original series.
+        """
+        parent_ts = self
+        
+        # Ensure data has time axis with size 1
+        if data.ndim == 0:
+            # Scalar → (1,)
+            reduced_data = np.array([data])
+        elif data.shape[0] != 1:
+            # Add time axis: (ensemble,) → (1, ensemble...)
+            reduced_data = np.expand_dims(data, axis=0)
+        else:
+            reduced_data = data
+        
+        class TemporalReducedTimeSeries(TimeSeries):
+            def __init__(self):
+                super().__init__()
+                self._reduced_data = reduced_data
+                self._parent = parent_ts
+                self._operation = operation_name
+            
+            def _get_not_indexed_data(self):
+                return self._reduced_data
+            
+            def get_index_of(self, *args, **kwargs):
+                # Delegate to parent for ensemble indexing
+                return self._parent.get_index_of(*args, **kwargs)
+            
+            def __getitem__(self, key):
+                """Support numpy-style indexing"""
+                return self._reduced_data[key]
+            
+            @cache
+            def _get_time_vector(self):
+                # Single-element time vector: mean of parent times
+                parent_time = self._parent.get_time_vector()
+                if isinstance(parent_time, u.Quantity):
+                    return np.array([np.mean(parent_time.value)]) * parent_time.unit
+                else:
+                    return np.array([np.mean(parent_time)])
+            
+            @cached_property
+            def delta_time(self):
+                # Delta time not meaningful for single-timestamp series
+                return 0 if not isinstance(self._parent.delta_time, u.Quantity) else 0 * self._parent.delta_time.unit
+        
+        return TemporalReducedTimeSeries()
+    
+    @property
+    def value(self):
+        """
+        Extract final value(s) from TimeSeries (convenience accessor).
+        
+        Returns the underlying data as a numpy array or scalar,
+        similar to pandas .values. Useful for getting final results
+        from chained operations without explicit numpy conversion.
+        
+        Returns
+        -------
+        float, int, or ndarray
+            - If shape is (1,): returns scalar
+            - If shape is (1, n): returns 1D array of length n
+            - Otherwise: returns the full data array
+        
+        Examples
+        --------
+        >>> # Extract scalar from fully reduced series
+        >>> scalar = ts.ensemble_rms.time_mean.value  # → float
+        >>> 
+        >>> # Extract array from partially reduced series  
+        >>> array = ts.time_mean.value  # → ndarray(ensemble_shape)
+        >>> 
+        >>> # Works like pandas .values
+        >>> values = ts.value  # → full data array
+        """
+        data = self._get_not_indexed_data()
+        
+        # Remove trivial dimensions and extract scalar if possible
+        squeezed = np.squeeze(data)
+        
+        if squeezed.ndim == 0:
+            # Scalar (0D array) → Python scalar
+            return squeezed.item()
+        else:
+            return squeezed
+    
+    @property
+    def ensemble_rms(self):
+        """
+        RMS over ensemble dimensions (chainable property).
+        
+        Returns a TimeSeries containing the RMS computed across all
+        ensemble (non-time) dimensions at each time step.
+        The result can be chained with time aggregation operations.
+        
+        Returns
+        -------
+        TimeSeries
+            Time series of ensemble RMS values (numpy-compatible via __array__)
+        
+        Notes
+        -----
+        This property:
+        - Works on ALL data (no filtering)
+        - Returns TimeSeries (chainable with .time_mean, .time_std, etc.)
+        - Is numpy-compatible via __array__ protocol
+        
+        For filtered data, use upstream filtering:
+        ``ts.with_modes([2,3,4]).with_times([1,2]).ensemble_rms``
+        
+        For legacy array return, use: :meth:`get_ensemble_rms` (deprecated)
+        
+        Examples
+        --------
+        >>> # Chainable operations
+        >>> ts = WavefrontSeries(...)  # shape (n_frames, ny, nx)
+        >>> rms_series = ts.ensemble_rms  # shape (n_frames,) - chainable!
+        >>> mean_rms = rms_series.time_mean  # scalar - fluent API!
+        >>> 
+        >>> # Numpy/matplotlib compatible:
+        >>> plt.plot(time, rms_series)  # Works via __array__()
+        >>> np.mean(rms_series)  # Works!
+        >>> 
+        >>> # With filtering (upstream):
+        >>> mean_rms = ts.with_modes([2,3,4]).ensemble_rms.time_mean
+        """
+        data = self._get_not_indexed_data()
+        axis = self._data_sample_axes(data)
+        
+        if isinstance(data, np.ma.MaskedArray):
+            rms_data = np.sqrt(np.ma.mean(np.abs(data)**2, axis=axis))
+        else:
+            rms_data = np.sqrt(np.mean(np.abs(data)**2, axis=axis))
+        
+        return self._create_reduced_series(rms_data, operation_name='ensemble_rms')
+    
+    @property
+    def time_mean(self):
+        """
+        Mean over time dimension (chainable property).
+        
+        Computes the average across time (axis 0), returning a
+        TimeSeries with time_size=1 containing the temporal mean.
+        Further operations (like ensemble_rms, ensemble_ptp) can be chained.
+        
+        Returns
+        -------
+        TimeSeries
+            TimeSeries with shape (1, ...ensemble_shape...) (chainable)
+            Use .value to extract the final array/scalar.
+        
+        Notes
+        -----
+        Chainable operation: returns TimeSeries (not array).
+        For convenient array extraction, use .value:
+        ``ts.time_mean.value`` → ndarray or scalar
+        
+        Examples
+        --------
+        >>> ts = WavefrontSeries(...)  # shape (n_frames, ny, nx)
+        >>> mean_ts = ts.time_mean  # TimeSeries(1, ny, nx) - chainable!
+        >>> mean_wf = ts.time_mean.value  # ndarray(ny, nx) - extracted
+        >>> 
+        >>> # Chaining works both ways now:
+        >>> rms_series = ts.ensemble_rms  # (n_frames,)
+        >>> mean_rms = rms_series.time_mean.value  # scalar
+        >>> 
+        >>> # NEW: time-then-ensemble operations
+        >>> ptp_map = ts.time_mean.ensemble_ptp.value  # peak-to-valley of long-exposure
+        """
+        data = self._get_not_indexed_data()
+        if isinstance(data, np.ma.MaskedArray):
+            mean_data = np.ma.mean(data, axis=0)
+        else:
+            mean_data = np.mean(data, axis=0)
+        
+        return self._create_temporal_reduced_series(mean_data, operation_name='time_mean')
+    
+    @property
+    def time_std(self):
+        """
+        Standard deviation over time dimension (chainable property).
+        
+        Computes the std across time (axis 0), returning a
+        TimeSeries with time_size=1 containing the temporal std.
+        Further operations (like ensemble_rms, ensemble_max) can be chained.
+        
+        Returns
+        -------
+        TimeSeries
+            TimeSeries with shape (1, ...ensemble_shape...) (chainable)
+            Use .value to extract the final array/scalar.
+        
+        Notes
+        -----
+        Chainable operation: returns TimeSeries (not array).
+        For convenient array extraction, use .value:
+        ``ts.time_std.value`` → ndarray or scalar
+        
+        Examples
+        --------
+        >>> ts = WavefrontSeries(...)  # shape (n_frames, ny, nx)
+        >>> std_ts = ts.time_std  # TimeSeries(1, ny, nx) - chainable!
+        >>> std_wf = ts.time_std.value  # ndarray(ny, nx) - extracted
+        >>> 
+        >>> # Chaining:
+        >>> rms_series = ts.ensemble_rms  # (n_frames,)
+        >>> std_rms = rms_series.time_std.value  # scalar
+        >>> 
+        >>> # NEW: time-then-ensemble operations
+        >>> max_std = ts.time_std.ensemble_max.value  # maximum variability
+        """
+        data = self._get_not_indexed_data()
+        if isinstance(data, np.ma.MaskedArray):
+            std_data = np.ma.std(data, axis=0)
+        else:
+            std_data = np.std(data, axis=0)
+        
+        return self._create_temporal_reduced_series(std_data, operation_name='time_std')
 
     @modify_help(call='power(from_freq=xx, to_freq=xx, [series_idx])')
     def power(self, *args, from_freq=None, to_freq=None,

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -128,7 +128,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         Examples
         --------
         >>> ts = MyTimeSeries(data)
-        >>> rms = ts.ensemble_rms_property  # Returns TimeSeries
+        >>> rms = ts.ensemble_rms  # Returns TimeSeries
         >>> plt.plot(rms)  # Works! __array__() called automatically
         >>> mean_rms = np.mean(rms)  # Works!
         """

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -636,7 +636,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         
         class FilteredTimeSeries(TimeSeries):
             def __init__(self):
-                super().__init__()
+                super().__init__(axes=parent_ts.axes)
                 self._parent = parent_ts
                 self._filter_args = filter_args
                 self._filter_kwargs = filter_kwargs

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -39,12 +39,17 @@ class TimeSeries(metaclass=abc.ABCMeta):
     - :meth:`_get_not_indexed_data`: Return raw data as numpy array with time as first axis
     - :meth:`get_index_of`: Define ensemble indexing logic (select specific elements)
     
-    The class supports:
+    The class provides a **chainable fluent API** for data analysis:
     
-    - Time-domain statistics (mean, std, rms over time for each ensemble element)
-    - Ensemble statistics (mean, std, rms across ensemble at each time step)
+    - Ensemble reductions: `ensemble_rms`, `ensemble_mean`, `ensemble_std`, `ensemble_median`, `ensemble_ptp`
+    - Time reductions: `time_mean`, `time_std`, `time_rms`, `time_median`, `time_ptp`
+    - Filtering: `filter(modes=..., times=...)` or `with_times(...)`
+    - Value extraction: `.value` property (like pandas)
+    - Chain operations: `ts.filter(modes=[2,3]).ensemble_rms.time_mean.value`
+    
+    Additional features:
+    
     - Power spectral density analysis with Welch method
-    - Time-based filtering (analyze specific time intervals)
     - Physical units support via astropy.units
     - Masked arrays for missing/invalid data (e.g., points outside circular pupil)
     
@@ -85,8 +90,11 @@ class TimeSeries(metaclass=abc.ABCMeta):
     >>> # Analyze DM commands for 1000 time steps, 100 actuators
     >>> dm_commands = np.random.randn(1000, 100)
     >>> ts = MyTimeSeries(dm_commands)
-    >>> rms_per_actuator = ts.time_rms()  # RMS over time for each actuator
-    >>> avg_command = ts.ensemble_average()  # Average across actuators at each time
+    >>> 
+    >>> # Fluent API (chainable)
+    >>> mean_rms = ts.ensemble_rms.time_mean.value  # Scalar
+    >>> rms_time_series = ts.filter(elements=[0,1,2]).ensemble_rms.value  # Array
+    >>> long_exposure_ptp = ts.time_mean.ensemble_ptp.value  # Peak-to-valley
     '''
 
     def __init__(self, axes=None):
@@ -325,8 +333,18 @@ class TimeSeries(metaclass=abc.ABCMeta):
         return math.prod(data.shape[1:])
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def time_median(self, *args, times=None, **kwargs):
-        '''Median over time for each series'''
+    def get_time_median(self, *args, times=None, **kwargs):
+        '''Median over time for each series
+        
+        .. deprecated::
+           Use the `time_median` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_time_median() is deprecated. Use the 'time_median' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.median(data, axis=0)
@@ -369,16 +387,36 @@ class TimeSeries(metaclass=abc.ABCMeta):
         return np.mean(data, axis=0)
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def time_rms(self, *args, times=None, **kwargs):
-        '''Root-Mean-Square value over time for each series'''
+    def get_time_rms(self, *args, times=None, **kwargs):
+        '''Root-Mean-Square value over time for each series
+        
+        .. deprecated::
+           Use the `time_rms` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_time_rms() is deprecated. Use the 'time_rms' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         x = self.get_data(*args, times=times, **kwargs)
         if isinstance(x, np.ma.MaskedArray):
             return np.sqrt(np.ma.mean(np.abs(x)**2, axis=0))
         return np.sqrt(np.mean(np.abs(x)**2, axis=0))
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def time_ptp(self, *args, times=None, **kwargs):
-        '''Peak-to-peak (max - min) over time for each series'''
+    def get_time_ptp(self, *args, times=None, **kwargs):
+        '''Peak-to-peak (max - min) over time for each series
+        
+        .. deprecated::
+           Use the `time_ptp` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_time_ptp() is deprecated. Use the 'time_ptp' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.ptp(data, axis=0)
@@ -386,24 +424,54 @@ class TimeSeries(metaclass=abc.ABCMeta):
 
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def ensemble_average(self, *args, times=None, **kwargs):
-        '''Average across series at each sampling time'''
+    def get_ensemble_average(self, *args, times=None, **kwargs):
+        '''Average across series at each sampling time
+        
+        .. deprecated::
+           Use the `ensemble_mean` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_average() is deprecated. Use the 'ensemble_mean' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.mean(data, axis=self._data_sample_axes(data))
         return np.mean(data, axis=self._data_sample_axes(data))
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def ensemble_std(self, *args, times=None, **kwargs):
-        '''Standard deviation across series at each sampling time'''
+    def get_ensemble_std(self, *args, times=None, **kwargs):
+        '''Standard deviation across series at each sampling time
+        
+        .. deprecated::
+           Use the `ensemble_std` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_std() is deprecated. Use the 'ensemble_std' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.std(data, axis=self._data_sample_axes(data))
         return np.std(data, axis=self._data_sample_axes(data))
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def ensemble_median(self, *args, times=None, **kwargs):
-        '''Median across series at each sampling time'''
+    def get_ensemble_median(self, *args, times=None, **kwargs):
+        '''Median across series at each sampling time
+        
+        .. deprecated::
+           Use the `ensemble_median` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_median() is deprecated. Use the 'ensemble_median' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.median(data, axis=self._data_sample_axes(data))
@@ -437,8 +505,18 @@ class TimeSeries(metaclass=abc.ABCMeta):
         return np.sqrt(np.mean(np.abs(data)**2, axis=self._data_sample_axes(data)))
 
     @modify_help(arg_str='[series_idx], [times=[from,to]]')
-    def ensemble_ptp(self, *args, times=None, **kwargs):
-        '''Peak-to-peak (max - min) across series at each sampling time'''
+    def get_ensemble_ptp(self, *args, times=None, **kwargs):
+        '''Peak-to-peak (max - min) across series at each sampling time
+        
+        .. deprecated::
+           Use the `ensemble_ptp` property instead. This method will be removed in a future version.
+        '''
+        import warnings
+        warnings.warn(
+            "get_ensemble_ptp() is deprecated. Use the 'ensemble_ptp' property instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.get_data(*args, times=times, **kwargs)
         if isinstance(data, np.ma.MaskedArray):
             return np.ma.ptp(data, axis=self._data_sample_axes(data))
@@ -920,6 +998,164 @@ class TimeSeries(metaclass=abc.ABCMeta):
             std_data = np.std(data, axis=0)
         
         return self._create_temporal_reduced_series(std_data, operation_name='time_std')
+    
+    @property
+    def ensemble_mean(self):
+        """
+        Mean over ensemble dimensions (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            Mean across ensemble at each time step (chainable)
+        
+        Examples
+        --------
+        >>> mean_series = ts.ensemble_mean.value  # Shape: (n_times,)
+        >>> overall_mean = ts.ensemble_mean.time_mean.value  # Scalar
+        """
+        data = self._get_not_indexed_data()
+        axis = self._data_sample_axes(data)
+        if isinstance(data, np.ma.MaskedArray):
+            mean_data = np.ma.mean(data, axis=axis)
+        else:
+            mean_data = np.mean(data, axis=axis)
+        return self._create_reduced_series(mean_data, operation_name='ensemble_mean')
+    
+    @property
+    def ensemble_std(self):
+        """
+        Standard deviation over ensemble dimensions (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            Std across ensemble at each time step (chainable)
+        
+        Examples
+        --------
+        >>> std_series = ts.ensemble_std.value
+        >>> mean_std = ts.ensemble_std.time_mean.value
+        """
+        data = self._get_not_indexed_data()
+        axis = self._data_sample_axes(data)
+        if isinstance(data, np.ma.MaskedArray):
+            std_data = np.ma.std(data, axis=axis)
+        else:
+            std_data = np.std(data, axis=axis)
+        return self._create_reduced_series(std_data, operation_name='ensemble_std')
+    
+    @property
+    def ensemble_median(self):
+        """
+        Median over ensemble dimensions (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            Median across ensemble at each time step (chainable)
+        
+        Examples
+        --------
+        >>> median_series = ts.ensemble_median.value
+        >>> time_avg_median = ts.ensemble_median.time_mean.value
+        """
+        data = self._get_not_indexed_data()
+        axis = self._data_sample_axes(data)
+        if isinstance(data, np.ma.MaskedArray):
+            median_data = np.ma.median(data, axis=axis)
+        else:
+            median_data = np.median(data, axis=axis)
+        return self._create_reduced_series(median_data, operation_name='ensemble_median')
+    
+    @property
+    def ensemble_ptp(self):
+        """
+        Peak-to-peak over ensemble dimensions (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            Peak-to-peak across ensemble at each time step (chainable)
+        
+        Examples
+        --------
+        >>> ptp_series = ts.ensemble_ptp.value
+        >>> mean_ptp = ts.ensemble_ptp.time_mean.value
+        """
+        data = self._get_not_indexed_data()
+        axis = self._data_sample_axes(data)
+        if isinstance(data, np.ma.MaskedArray):
+            ptp_data = np.ma.ptp(data, axis=axis)
+        else:
+            ptp_data = np.ptp(data, axis=axis)
+        return self._create_reduced_series(ptp_data, operation_name='ensemble_ptp')
+    
+    @property
+    def time_median(self):
+        """
+        Median over time dimension (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            TimeSeries with time_size=1 containing temporal median (chainable)
+        
+        Examples
+        --------
+        >>> median_wf = ts.time_median.value
+        >>> rms_of_median = ts.time_median.ensemble_rms.value
+        """
+        data = self._get_not_indexed_data()
+        if isinstance(data, np.ma.MaskedArray):
+            median_data = np.ma.median(data, axis=0)
+        else:
+            median_data = np.median(data, axis=0)
+        return self._create_temporal_reduced_series(median_data, operation_name='time_median')
+    
+    @property
+    def time_rms(self):
+        """
+        RMS over time dimension (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            TimeSeries with time_size=1 containing temporal RMS (chainable)
+        
+        Examples
+        --------
+        >>> rms_wf = ts.time_rms.value
+        >>> max_rms = ts.time_rms.ensemble_ptp.value
+        """
+        data = self._get_not_indexed_data()
+        if isinstance(data, np.ma.MaskedArray):
+            rms_data = np.sqrt(np.ma.mean(np.abs(data)**2, axis=0))
+        else:
+            rms_data = np.sqrt(np.mean(np.abs(data)**2, axis=0))
+        return self._create_temporal_reduced_series(rms_data, operation_name='time_rms')
+    
+    @property
+    def time_ptp(self):
+        """
+        Peak-to-peak over time dimension (chainable property).
+        
+        Returns
+        -------
+        TimeSeries
+            TimeSeries with time_size=1 containing temporal peak-to-peak (chainable)
+        
+        Examples
+        --------
+        >>> ptp_wf = ts.time_ptp.value
+        >>> mean_ptp = ts.time_ptp.ensemble_mean.value
+        """
+        data = self._get_not_indexed_data()
+        if isinstance(data, np.ma.MaskedArray):
+            ptp_data = np.ma.ptp(data, axis=0)
+        else:
+            ptp_data = np.ptp(data, axis=0)
+        return self._create_temporal_reduced_series(ptp_data, operation_name='time_ptp')
 
     @modify_help(call='power(from_freq=xx, to_freq=xx, [series_idx])')
     def power(self, *args, from_freq=None, to_freq=None,

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -986,7 +986,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         
         Computes the std across time (axis 0), returning a
         TimeSeries with time_size=1 containing the temporal std.
-        Further operations (like ensemble_rms, ensemble_max) can be chained.
+        Further operations (like ensemble_rms, ensemble_ptp) can be chained.
         
         Returns
         -------
@@ -1011,7 +1011,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         >>> std_rms = rms_series.time_std.value  # scalar
         >>> 
         >>> # NEW: time-then-ensemble operations
-        >>> max_std = ts.time_std.ensemble_max.value  # maximum variability
+        >>> ptp_std = ts.time_std.ensemble_ptp.value  # peak-to-peak temporal variability
         """
         data = self._get_not_indexed_data()
         if isinstance(data, np.ma.MaskedArray):

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -909,7 +909,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         - Is numpy-compatible via __array__ protocol
         
         For filtered data, use upstream filtering:
-        ``ts.with_modes([2,3,4]).with_times([1,2]).ensemble_rms``
+        ``ts.filter(modes=[2,3,4]).with_times([1,2]).ensemble_rms``
         
         For legacy array return, use: :meth:`get_ensemble_rms` (deprecated)
         
@@ -925,7 +925,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         >>> np.mean(rms_series)  # Works!
         >>> 
         >>> # With filtering (upstream):
-        >>> mean_rms = ts.with_modes([2,3,4]).ensemble_rms.time_mean
+        >>> mean_rms = ts.filter(modes=[2,3,4]).ensemble_rms.time_mean
         """
         data = self._get_not_indexed_data()
         axis = self._data_sample_axes(data)

--- a/arte/time_series/time_series.py
+++ b/arte/time_series/time_series.py
@@ -795,7 +795,7 @@ class TimeSeries(metaclass=abc.ABCMeta):
         
         class TemporalReducedTimeSeries(TimeSeries):
             def __init__(self):
-                super().__init__()
+                super().__init__(axes=parent_ts.axes)
                 self._reduced_data = reduced_data
                 self._parent = parent_ts
                 self._operation = operation_name

--- a/docs/notebook/time_series/time_series_examples.ipynb
+++ b/docs/notebook/time_series/time_series_examples.ipynb
@@ -1,0 +1,545 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TimeSeries Fluent API Examples\n",
+    "\n",
+    "This notebook demonstrates the new chainable fluent API for TimeSeries analysis.\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The fluent API provides:\n",
+    "- **Chainable properties**: All reductions return TimeSeries objects\n",
+    "- **`.value` property**: Extract final values (like pandas)\n",
+    "- **`.shape` property**: Access data shape like numpy arrays\n",
+    "- **Bidirectional chaining**: Both ensemble→time and time→ensemble work\n",
+    "- **Generic filtering**: `filter(**kwargs)` accepts any Indexer parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy import units as u\n",
+    "from arte.time_series.time_series import TimeSeries\n",
+    "from arte.time_series.indexer import ModeIndexer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a Concrete TimeSeries Implementation\n",
+    "\n",
+    "`TimeSeries` is an abstract base class. We need to implement the required methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ModalTimeSeries(TimeSeries):\n",
+    "    \"\"\"Concrete implementation of TimeSeries for modal coefficients.\"\"\"\n",
+    "    \n",
+    "    def __init__(self, data, time, indexer):\n",
+    "        super().__init__()\n",
+    "        self._data = data\n",
+    "        self._time = time\n",
+    "        self._indexer = indexer\n",
+    "    \n",
+    "    def _get_not_indexed_data(self):\n",
+    "        # Return data in (time, ensemble) shape\n",
+    "        return self._data.T\n",
+    "    \n",
+    "    def get_index_of(self, *args, **kwargs):\n",
+    "        return self._indexer.modes(*args, **kwargs)\n",
+    "    \n",
+    "    def _get_time_vector(self):\n",
+    "        return self._time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Sample Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created TimeSeries with shape: (100, 10)\n",
+      "  Time steps: 100\n",
+      "  Modes: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create synthetic modal coefficients\n",
+    "n_modes = 10\n",
+    "n_frames = 100\n",
+    "\n",
+    "time = np.linspace(0, 10, n_frames) * u.s\n",
+    "data = np.random.randn(n_modes, n_frames) * u.nm\n",
+    "\n",
+    "# Add some sinusoidal trends\n",
+    "for i in range(n_modes):\n",
+    "    data[i] += 10 * np.sin(2 * np.pi * time.value / (i + 1)) * u.nm\n",
+    "\n",
+    "ts = ModalTimeSeries(data, time=time, indexer=ModeIndexer(n_modes))\n",
+    "print(f\"Created TimeSeries with shape: {ts.shape}\")\n",
+    "print(f\"  Time steps: {ts.shape[0]}\")\n",
+    "print(f\"  Modes: {ts.shape[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Chainable Operations\n",
+    "\n",
+    "### Ensemble Operations\n",
+    "\n",
+    "Compute statistics across the ensemble (spatial) dimension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ensemble RMS shape: (100,)\n",
+      "Result is TimeSeries: True\n",
+      "\n",
+      "Ensemble mean shape: (100,)\n",
+      "Ensemble std shape: (100,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ensemble RMS (RMS across modes at each time)\n",
+    "ens_rms = ts.ensemble_rms\n",
+    "print(f\"Ensemble RMS shape: {ens_rms.shape}\")\n",
+    "print(f\"Result is TimeSeries: {isinstance(ens_rms, TimeSeries)}\")\n",
+    "\n",
+    "# Ensemble mean\n",
+    "ens_mean = ts.ensemble_mean\n",
+    "print(f\"\\nEnsemble mean shape: {ens_mean.shape}\")\n",
+    "\n",
+    "# Ensemble standard deviation\n",
+    "ens_std = ts.ensemble_std\n",
+    "print(f\"Ensemble std shape: {ens_std.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Time Operations\n",
+    "\n",
+    "Compute statistics across the time dimension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time mean shape: (1, 10)\n",
+      "Result is TimeSeries: True\n",
+      "\n",
+      "Time RMS shape: (1, 10)\n",
+      "Time std shape: (1, 10)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Time mean (mean over time for each mode)\n",
+    "time_mean = ts.time_mean\n",
+    "print(f\"Time mean shape: {time_mean.shape}\")\n",
+    "print(f\"Result is TimeSeries: {isinstance(time_mean, TimeSeries)}\")\n",
+    "\n",
+    "# Time RMS\n",
+    "time_rms = ts.time_rms\n",
+    "print(f\"\\nTime RMS shape: {time_rms.shape}\")\n",
+    "\n",
+    "# Time standard deviation\n",
+    "time_std = ts.time_std\n",
+    "print(f\"Time std shape: {time_std.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chaining Operations\n",
+    "\n",
+    "The real power: chain multiple operations together!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chained result shape: (1,)\n",
+      "Chained result value: 6.9890517132354 nm\n",
+      "\n",
+      "Reversed chain shape: (1,)\n",
+      "Reversed chain value: 1.0172794024733252 nm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ensemble RMS, then time mean\n",
+    "mean_rms = ts.ensemble_rms.time_mean\n",
+    "print(f\"Chained result shape: {mean_rms.shape}\")\n",
+    "print(f\"Chained result value: {mean_rms.value}\")\n",
+    "\n",
+    "# Time mean, then ensemble RMS (bidirectional!)\n",
+    "rms_mean = ts.time_mean.ensemble_rms\n",
+    "print(f\"\\nReversed chain shape: {rms_mean.shape}\")\n",
+    "print(f\"Reversed chain value: {rms_mean.value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using .value to Extract Final Results\n",
+    "\n",
+    "Like pandas, use `.value` to get the final array or scalar:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Type without .value: <class 'arte.time_series.time_series.TimeSeries._create_temporal_reduced_series.<locals>.TemporalReducedTimeSeries'>\n",
+      "Shape: (1,)\n",
+      "\n",
+      "Type with .value: <class 'astropy.units.quantity.Quantity'>\n",
+      "Value: 6.9890517132354 nm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Without .value: returns TimeSeries\n",
+    "result_ts = ts.ensemble_rms.time_mean\n",
+    "print(f\"Type without .value: {type(result_ts)}\")\n",
+    "print(f\"Shape: {result_ts.shape}\")\n",
+    "\n",
+    "# With .value: extracts scalar or array\n",
+    "result_scalar = ts.ensemble_rms.time_mean.value\n",
+    "print(f\"\\nType with .value: {type(result_scalar)}\")\n",
+    "print(f\"Value: {result_scalar}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filtering with filter()\n",
+    "\n",
+    "Use `filter(**kwargs)` to select subsets before computing statistics:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filtered shape: (100, 3)\n",
+      "Original had 10 modes, filtered has 3 modes\n",
+      "\n",
+      "Low mode RMS: 6.980862943055743 nm\n",
+      "All mode RMS: 6.9890517132354 nm\n",
+      "Difference: 0.008188770179657467 nm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filter to specific modes\n",
+    "low_modes = ts.filter(modes=[2, 3, 4])\n",
+    "print(f\"Filtered shape: {low_modes.shape}\")\n",
+    "print(f\"Original had {ts.shape[1]} modes, filtered has {low_modes.shape[1]} modes\")\n",
+    "\n",
+    "# Chain filtering with operations\n",
+    "low_mode_rms = ts.filter(modes=[2, 3, 4]).ensemble_rms.time_mean.value\n",
+    "print(f\"\\nLow mode RMS: {low_mode_rms}\")\n",
+    "\n",
+    "# Compare with all modes\n",
+    "all_mode_rms = ts.ensemble_rms.time_mean.value\n",
+    "print(f\"All mode RMS: {all_mode_rms}\")\n",
+    "print(f\"Difference: {all_mode_rms - low_mode_rms}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualization Example\n",
+    "\n",
+    "Plot ensemble RMS over time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0EAAAIhCAYAAACIfrE3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAr4xJREFUeJzt3Qd4U3X3B/DTvVto6QJKS9l7b2QIIsutKC5w+7rFiRsXjr++zhc3bsUBKCAge8lGZtm0UErpppPu/J/zS25I0iRN0pvcm+T7eZ4+LeW2uU1vb+655/zO8dFoNBoCAAAAAADwEr5K7wAAAAAAAIArIQgCAAAAAACvgiAIAAAAAAC8CoIgAAAAAADwKgiCAAAAAADAqyAIAgAAAAAAr4IgCAAAAAAAvAqCIAAAAAAA8CoIggAAAAAAwKsgCAIAsMPXX39NPj4+Ft/Wrl3r1s8n7z//HL/99luj27700ktiW7kfW3rz8/Oj2NhYuuyyy2jHjh0Ntp8+fbrYLiIigsrKyhr8/8mTJ8nX11dsw/tq6ODBg3TLLbdQamoqBQcHU4sWLahv3770wAMPUElJiWqPgZSUFPFzO+LHH3+k9957z+z/mXuOAAA8mb/SOwAA4I7mzp1LnTt3bvD5rl27KrI/nuT111+n0aNHU01NDf377780a9YsGjlyJO3evZs6dOhgtG1AQADV1tbSvHnz6I477mjwO+IAyTSo4e85bNgw6tKlC73wwgsisMjPz6c9e/bQzz//TI8//jhFRkZ63DHAQdD+/fvpkUceafB/mzdvptatWyuyXwAASkAQBADggO7du1P//v3x3DkBBzqDBw8WH1900UXUrFkzmjZtGn3//fciIDIUGBgoMkVfffWVURCk0WhExub666+nzz//3OhrOBvCGSLO2HCQJLn22mvplVdeEV/rbceA9HwDAHgLlMMBADgJlxhxedV3330nsg6hoaHUq1cvWrx4sdF2eXl5dPfdd1NSUhIFBQWJEjDOVKxcudJoO/73mDFjRJaCvxdvs2rVKrMlanv37qXrrruOoqKiKDo6mmbMmCEyJocPH6bx48eLi3/OgLz11ltm972yslJ8TUJCAoWEhIhMDGdQbMFZmSFDhlBYWBiFh4fTpZdeavPXmiMFGjk5OWb///bbb6d//vlH/GyGzxWXw912220Nti8oKBDPIe+bOXKV+PXp00cEcabq6uqoVatWdPXVV+s/V1hYSPfdd5/4PAd2XKb37LPPUlVVlU2leRkZGWZLC6XSvFGjRtGSJUvEc2JYumetHI6zRldccQU1b95clAz27t2bvvnmG7OP89NPP4n9bdmypXhux44da/T7AABQGwRBAAAO4AtZDioM3/hzpvjC86OPPqKXX36Zfv/9dxGQXHXVVXTixAn9Nrw2ZeHChaI06++//6YvvvhCXETyxbqEsyDjxo0TF5h8IfrLL7+I78UBhmkgxKZMmSICLn7Mu+66i/773//So48+SldeeSVNmjSJFixYQBdffDE99dRTNH/+/AZf/8wzz4h95H3htzNnzogLacP9tlTKNnXqVFESxvvIAWBpaakIBtLS0hx4ponS09PF+44dO5r9f36ukpOTRTZI8uWXX9KIESMalM8xDtCys7PppptuonXr1tH58+edcgxwALZx40Y6evSo0dfx75ifTylA44CTy/++/fZbEXjyMXPzzTeLANUwUGqK//3vfyJo5qCWS9+kN0s4gBk6dCgdOHCAPvjgA3GM8O+U1yOZC5z5eOEAi4+Vzz77TPzMnKEz9zcBAKAKGgAAsNncuXO5Vsrsm5+fn9G2/Ln4+HhNSUmJ/nNnz57V+Pr6ambPnq3/XHh4uOaRRx6x+Jjl5eWa6OhozWWXXWb0+bq6Ok2vXr00AwcO1H/uxRdfFI/7zjvvGG3bu3dv8fn58+frP1dTU6OJjY3VXH311frPrVmzRmzXt29fTX19vf7zGRkZmoCAAM2dd97Z4LEkp06d0vj7+2sefPBBo8cuLS3VJCQkaKZMmWLxZzR87Hnz5ol9q6io0GzatEnTqVMnTdeuXTVFRUVG20+bNk0TFham3xd+DP66goICTVBQkObrr7/W5OXlie/J/y+prKzUXHnllUa/tz59+mieffZZTW5urkauYyA/P18TGBioeeaZZ4y+np8HPi54X9knn3wivvaXX34x2u7NN98Un//777/1n0tOThY/t+m+pKenm30u+b1k0qRJ4uvNMX2ObrjhBvEc8u/U0IQJEzShoaGac+fOGT3OxIkTjbbjn4U/v3nzZqvPJQCAUpAJAgBwAN+13759u9Hb1q1bG2zHd/gN153Ex8dTXFycuGsuGThwoChrevXVV2nLli2iIYAhLvXicileF2OYdaivrxelbfzY5eXlRl8zefJko39zOR6XLU2YMEH/OX9/f2rfvr3RvkhuvPFGo3IpzrRwZmDNmjUWn5Ply5eL/br11luN9pNLqbicztauabyOhxseSCV/3NiAsyO8NsgSzqpwudzSpUvphx9+ECVlXA5oDpccciaMM1OcIbvhhhtESeJrr70mnidby7gaOwZiYmJENoQzd/y7YkVFRfTHH3+I54iff7Z69WpROshrkgxJXeDMZfqcjfeJSy+5RNN0nyoqKhpkkS6//HKjf/fs2VO8N3dsAQCoARojAAA4gC+WbVkUzxfC5i7CDUuweA0NB0BcSvT888+LtSpcMsdlR1y+JK2FMb1INsRBEl9IS7hUzhAHBRxUcEBi+nlzLaH5cc19jjuoWSLt54ABA8z+PzcjsMWbb74pSvX4YptLx2bPni3K+DjA4OfOHA7S+KKdS+J4fQwHNvzz8vew9jvkN8bJEG6YwOVo/DvgUj45jgFer8QliStWrBCli7x2htf5GLa55rJHfm5N1yJxsMyBkmFZpKvwYyYmJjb4PK/5kf7f2nEu/Z4cLTUEAHA2BEEAAArjGTV8Ac5vp06doj///JOefvppys3NpWXLlon/Zx9++KHFLl6cYZLT2bNnzX7OXFAnkfaTZwxxUOIobgogBRe8rocbMzz33HPi5+f21dYCDl5Lw1mXOXPm2PWYHIDwmileu8UNAeTCgQ8HDtxOmz/m94MGDTJqo83PKQd4HIgZBkL8++dMmvS8miMFtaYNFLjld1PwPvG6KVO8lolZ2ycAAHeAcjgAABVp06aN6Ch3ySWX0K5du8TnuCSMS8G4fIuDA3NvnNGRE2csDFtFc1kTl+VxcwRL+CKfMxfHjx+3uJ+OePLJJ0XZ3htvvCGaLFjC2TN+42DIWstncxf30gU+Z8WkbIcceOCr1Phiw4YNYugr758hzmDxsFfexhCX20n/bwl3+GPcDdAQB9KNZSCt4cfkkjgp6DHcJ86woaU2ALg7ZIIAABzA2QK+S2+qXbt2osW1rYqLi8W6IV6Dw4M3ef0Qry3hDJDUGYzL4zgLwmuCuOyNy+K4VIrXsXB5Gr+3N/PRGM5CcEDBneV4H1988UWRdZg5c6bVC3LOpHCrZO4ix+uVuL0yl8lt27ZNlOuZzvmxBa8P4q5z3PHu/fffF1khc3j/OAvVGG5Hfu7cObrmmmvErB8OVA4dOiTWB3HJHnfMk/MY4KCHS/z4d8xZLV7zZIjXB3388cfi98ulfD169BBd5fhnnjhxouh+ZwmXHnbq1ElkyHhf+Pnm9U789ab4+3KXNz5W+vXrJ35WS4Ep/765lTsfm9y1kMsrea0Vr83iMk1uvQ4A4M4QBAEAOMDc/BnGgznvvPNOm78PX7hzeRS3kuYLYG6KwNkgvhDnDIiEy7z483wBes8994iMCAdCPLvFcH2JXPgCnIMx/jk5O8LNG37++WdxgW8NB0lc6sXBirT+hde78MX6vffe6/D+cJMDfp7effddevDBB5t0Ec5fz+uw+HeVlZUlmkpw0MKtsznTYWuWw9ZjgFt7c1MJzqRxW27TfedjgBtOcPD49ttvi6CW5wVxYMPBiDUcwC1atEhkD/n55WwPr4fituzcCt3Qww8/LFpecztrDmw502dpMCwHVry/vO39998vMki8BorL+ZxxvAEAuJoPt4hz+aMCAAAAAAAoBGuCAAAAAADAqyAIAgAAAAAAr4IgCAAAAAAAvAqCIAAAAAAA8CoIggAAAAAAwKsgCAIAAAAAAK/i1nOC6uvrxTRrHi7o4+Oj9O4AAAAAAIBCePIPz9Fr2bKlGAjtsUEQB0BJSUlK7wYAAAAAAKhEZmYmtW7d2nODIM4AST9oZGSk4lkpnvLNU8cbizwBcMwAzjPgCnhtAhwz4E3nmZKSEpEgkWIEjw2CpBI4DoDUEARVVlaK/VD6AAD3gGMGcMwAzjOgNnhtAk84ZmxZJqOOPQUAAAAAAHARBEEAAAAAAOBVEAQBAAAAAIBXces1QQAAAACeoq6ujmpqahRf38H7wGs81LK+A9St3oXHjJ+fH/n7+8syGgdBEAAAAIDCysrK6PTp02LOiZL48fmilmetYAYjqPGYCQ0NpcTERAoMDGzS90EQBAAAAKBwBogDIL644zbDSgYffEFbW1sr29128HwaFx0z/DjV1dWiHXd6ejp16NChSZknRYMgjhiff/55WrBgAeXm5lKfPn3o/fffpwEDBii5WwAAAAAuw6VEfIHHAVBISIiizzyCIFDzMcN/HwEBAXTy5EkREAUHBzv8vRQt9rzzzjtpxYoV9N1339G+ffto3LhxNHbsWMrKylJytwAAAABcDpkXgMbJte5IsSDo/Pnz9Pvvv9Nbb71FI0aMoPbt29NLL71Ebdu2pTlz5ii1WwAAAAAA4OEUK4fjtBnXwJqmsTjNtXHjRrNfU1VVJd4kJSUl4j0vxuI3JfHjSwvDAHDMAM4zoAZ4bXKv35P0pjRpH9SwL+AeNC48ZqS/E3PX//ZchysWBEVERNCQIUPolVdeoS5dulB8fDz99NNPtHXrVrHQyZzZs2fTrFmzGnyeF0hxWz4l8ZNeXFwsfiloKQk4ZgDnGVADvDa5z5og/l3xDWJ+UxJfx/BNak8uz8vIyKCOHTvStm3bqHfv3ma3WbduHV1yySVizXqzZs1cvo/uROPiY4b/RvjvpaCgQKwPMu034BaNEXgt0O23306tWrUSfb/79u1LN954I+3atcvs9jNnzqQZM2YYZYKSkpLEQsLIyEhSEv8y+BfP+4IgCHDMAM4zoAZ4bXIPfCOXL954YTm/qYHpxaU5t912G33zzTcNPn/ppZfS0qVLSa2k59ja883XpY1t05ivv/5aXOdK4uLiaODAgeKmfrdu3Ro8j3fffTd98sknRt/jvvvuE5+bNm0azZ07V3yOAzNuLLZs2TLKycmh5s2bU69evejFF18UCQY1HzNy4N8HX2vHxMQ0qCizp1GCon9p7dq1E5F2eXm5CGi45/f1118v1gWZExQUJN5M8ROhhsCDgyC17Au4BxwzgGMGcJ4Bvm7g1wPpTem7+tI+2LIv48eP11+cS/haTemfwxrDn8/SftqyjS2PwzfpDx8+LJ5Xbvz15JNP0uTJk+nIkSNGc274pv68efPovffe03cI5OD4559/pjZt2hjt07XXXiuyhxw4paamikBo1apVVFRUpMjzrrHzmGkq6Xdi7prbnmtwVVyth4WFiQCIf3nLly+nK664QuldAgAAAFAEX1RWVNcq8mbvmg4OeBISEozeODMh4YvVL774gq666ioxB4mXPPz555/6/+drv5tuuknfHpz/3zCo4sCBb5Dz9+Q7/3yNyOVskunTp9OVV15Jr7/+ulhawaVrvHSCS6aeeOIJio6OptatW9NXX33VYN8PHTpEQ4cOFdkDzsysXbvW6s/6zz//iGZevJ8ctDz00EPiRr41/PPzc8LXuf3796dHH31UtHfmwMgQV0NxsDN//nz95/hjfhweISM5d+6cWDv/5ptv0ujRoyk5OVlkl7haatKkSVb3BVSUCeKAh//YOnXqRMeOHRMHK3/MaUEAAAAAb3S+po66vrBckcc+MGscBcp8i5yDEu4G/Pbbb9OHH34ogh4OBDhA4bKutLQ0UT7XokULcT3IHYRZRUWFuNC/6KKLaP369aIM6tVXXxXZp7179+ozKatXrxaBDm+zadMmuuOOO2jz5s0iYOG15pxhuffee8UaHw4qJHzdyZmXrl270rvvvkuXX365GMLJwZYpHuXCZX68lv3LL78U69EfeOAB8WaaCbOEA5gff/zRYukYX//y9+Lnh3HgxuV0hsFZeHi4eFu4cCENHjzYbIUUuEEmiBsJ3H///dS5c2e69dZbafjw4fT333+7rKYQAAAAABy3ePFi/YW59MaBgiHO1kydOlWMQ+GMDWdPuCkBO3XqlMh0cJYkJSVFzIu87LLLxP9xKRiXN3EmqUePHqKRFgcJ/DWGgQEHUx988IG4kc5BA7/nAOqZZ54RmSXOknDAxAGSIQ5grrnmGvF9eTxLVFSUCHDM4QCO160/8sgj4ntyBokf89tvv7XanIuvdfk54aonzmbxz8TBFl/7mrrllltEloczXRwk8v7efPPNRttwIMhrjbgUjrNew4YNEz8nB4XgRpmgKVOmiDcASw6cKabWzUMpKgSBMQAAeIeQAD9Ke/lSRR472N9X3+nLFpypMZ3vyEGJoZ49e+o/5mCAOwTz4n72n//8RwQi3BRr3LhxorSNAwy2c+dOkRni7Q1x0HH8+HH9v7mUzXAtCJfFde/e3ajJAWd3pMeUGDYR4OCCA7GDBw+a/Tmlffnhhx/0n5PaNHP2iAMpc3jf+Wfj8jxeB8/BlGnzAwlnwrikjQMc/t78MX/OFD9f/H8bNmwQGS9ukMCZNg4WOeAE26ijBQmAhQBo0gcbKSUmlP58cDhFBiMQAgAAz8frSEIDlblEs3dNEAc1nOGxxrTCh38+aZ7LhAkTRNZjyZIltHLlShozZoyoEvq///s/sU2/fv2MAg8JryGy9v2tPaY1lhb289fec889Yh2QKalxgTkcnEnPD2d/zp49K9Y4cemeOZzJ4gwV+/jjjy1+X17HxOV9/PbCCy/QnXfeKbrDIQgi92qMAGDOtvRC8T6joIJmzt+HoW0AAAAeiAMavnj//vvvxRqdzz77TN8s4OjRo6K1NAcShm9cutZUW7Zs0X/MmRrO9pgrU5P25cCBAw32g98Mu7w1hhsj7NmzhxYsWGD2/3m9U3V1tXjjNUi24nVNjTVpAGMIgkC10s6U6D9esjebvt96StH9AQAAAGNVVVUiu2H4lp+fb/PTxFmMP/74Q5SacZDBa4yk0jJuEMDlYNwRjku/uOyMS8oefvhhOn36dJN/FZxp4WCEu8Rx9ok71RnO9TH01FNPidIz3m737t0iOOMudw8++KBdj8kts6WsjbmsG5fucUkev0mzigzxgNCLL75YBIy8Doifk19//VWUw6G7sn0QBIFqHdAFQcPaa7u0vLI4TZTIAQAAgDrwehRu/2z4xo2ubMVZFG5cwOuGuJsbX/hz8wDGLbW5bIzLza6++moRHHGQwt3jOJhoqjfeeEO0muZBoxxkcTBmbg0O4/3jAIyDH+5Wx80cuLMd/7z24iCOgxwOXszhn83Sz8dNFgYNGkT//e9/xfPFa594P+666y766KOP7N4Xb+ajsbf4U0V4wCqnQ7nzhhx/DE3BtaK84I5TthiW2nTVtfXU7cVlVFOnoQ1PjqaX/jxAqw7lUtsWYfTnA8MowgPWB+GYARwzgPMMSAv9+Y4+D4u3Z+K9M/BlIZeGcaMANQ88BfXQuPiYsfb3Yk9sgEwQqNKx3DIRAEUE+1Pr5iH0f9f1opZRwZSeX07PLNiP9UEAAAAA4DAEQaBKadnaUriuiZHirkLzsED68MY+5OfrQ4v2nKGftmUqvYsAAAAA4KYQBIGqmyJ0bXkhldkvOZqeuLST+PilRQeMGicAAAAAANgKQRCoUlp2sT4TZOjui1JpdKdYsWbogR93UVlVrUJ7CAAAAADuCkEQqHKBnZTl6dbSeA6Ar68PvTOlNyVEBtOJ/HJ68Y8DCu0lAAAAALgrBEGgOqeLzlNJZS0F+PlQ+7jwBv8frVsfxBb8e5pySysV2EsAAAAAcFcIgkC1TRE6xEVQoL/5Q3RASjT1SmpG9Rqi5fvPungPAQAAAMCdIQgCt2iKYM7kHtoBZYv2ZrtkvwAAAADAMyAIAlW3x7ZmYk9tELQ9o5BySlASBwAAAAC2QRAEbpsJatUshPq2aUYaDdHSfdle1zziuYX76O3lh5TeFQAAp1iRlkPfbTmJ4dhu7KWXXqLevXsrvRsAZiEIAlU5V1FNWefO2xQEsUk9W4r3S7wsCDqWW0bfbzlFH685TpmFFUrvDgCArKpq68QYhOcX7qevNmXg2VUhHmRu7W369On0+OOP06pVq1y+bxkZGWIf/P39KSsry+j/srOzxef5/3k7T3Dw4EG6/PLLKSoqiiIiImjw4MF06tQpi9vX1NTQyy+/TO3ataPg4GDq1asXLVu2zGib0tJSeuSRRyg5OZlCQkJo6NChtH37dvIkCIJAlaVwSdEhFBkc0Oj2E3skiPfbM4robLH3lMQdzinVf7zqYI6i+wIAILdD2aVUVVsvPp7910FR9gzqwsGE9Pbee+9RZGSk0efef/99Cg8Pp5iYGMX2sWXLlvTtt98afe6bb76hVq1akac4fvw4DR8+nDp37kxr166lPXv20PPPPy+CG0uee+45+vTTT+nDDz+ktLQ0uvfee+mqq66if//9V7/NnXfeSStWrKDvvvuO9u3bR+PGjaOxY8c2CCrdGYIgUGcpXCPrgSSJUSHUP7m5+PgvL8oGHckp03+86lCuovsCACC3vafPifc+PkS19Rq6/4ddlFda5X1PdHm55bfKStu3PX/etm3tkJCQoH/jDARnVkw/Z1oOx9mhK6+8kl5//XWKj4+nZs2a0axZs6i2tpaeeOIJio6OptatW9NXX31l9Fh84X399ddT8+bNRVB1xRVX2JTFmTZtGs2dO9foc19//bX4vCkOBiZOnCgCN963W265hfLz8/X/z5kSDjZ4n3kfJk+eLAIQ0+zT/PnzafTo0RQaGioyLJs3byZnevbZZ8V+v/XWW9SnTx9KTU2lSZMmUVxcnMWv4cDmmWeeEV/H2//nP/+hSy+9lN555x3x/+fPn6fff/9dfM8RI0ZQ+/btxe+ybdu2NGfOHIvfV/p98/dPSUkRx8ANN9wgskqSUaNG0YMPPiiyTPz75Of6s88+o/LycrrttttEJoszVEuXLiVnQxAEKm2KYDwk1ZpJugYJ3lQSd+TshRPKlhMFVFZVq+j+AADIac/pYvH+9mFtxby43NIqevCnXVRbp80OeY3wcMtv11xjvC1f9FradsIE421TUsxv5wKrV6+mM2fO0Pr16+ndd98VF84cUPAF8datW0VWgt8yMzPF9hUVFSKo4OCEv2bjxo3i4/Hjx1N1dbXVx+ISsaKiIvE1jN8XFhbSZZddZrQdZ65GjhwpLuB37NghAp6cnByaMmWKfhu+SJ8xY4YoCeMSP19fX5E9qa+vbxCUcBng7t27qWPHjjR16lQR5FkyYcIE8fNYe7OEH3vJkiXicTiI4cBn0KBBtHDhQqvPS1VVVYNMEZe8Sc8T729dXZ3VbSzhwJAff/HixeJt3bp19MYbbzTIxrVo0YK2bdsmAiIOwq677jpRcrdr1y7xs3AQyr97Z0IQBG7ZFMHQhO6J4m7hzpNFdEa3nsjTHcnVBkG+PkQ1dRracCRP6V0CAJA9EzQkNYY+ubkfhQX60ZYThfR/fx/Bs+zmONvzwQcfUKdOnej2228X7/lilzMTHTp0oJkzZ1JgYCBt2rRJbP/zzz+LgOOLL76gHj16UJcuXUR2h9e8cPmXNQEBAXTzzTfrM0v8nv/NnzfE2Y2+ffuKDBWXlXFGhbdds2YNHTmiPeauueYauvrqq8U+crD05ZdfijIxziAZ4gCIMzEcmHCW6+TJk3Ts2DGL+8g/FwdM1t4syc3NpbKyMhFkcFD4999/i8CM95ODD0s4yHj33Xfp6NGjIpDisrc//vhDBIOMszFDhgyhV155RQSsHBB9//33IkiVtrGEvx9n27p3704XXXSRCGZM14VxhoxL8qTfNwdXHBTddddd4nMvvPACFRQU0N69e8mZ/J363QHsXAjLC/7tDYISooJpQHI0bcsoFCVxd16U6vDz/r+1x2jxnmz6cnp/UWqnRpU1dZSRX65vDLFozxlaeTCXJujmJgEAuLPyqlr9a0HPpCiKiwimN6/tSQ/8+C99su449WnTjC7tpl0P6vHKLpQ+N+DnZ/zvXCul0b4m97wVbAjQrVs3EdRIuByKL5glfn5+otyML/DZzp07RRDBF+aGKisrjcrRLLnjjjvEBT0HOL/++qsoTzPNzPBjcMBjLuvCj8EBDb/ntTZbtmwRZXJSBoiDMcP979mzp/7jxETt6zL/LBxcmdOU9UnSPnB54KOPPio+5gDtn3/+oU8++URkt8zh9Vp33XWX2Ccu4ePyMy5FMywd5JI2DlJ5//h3wkHijTfeKDI11nAZnOHvip8D6Xdp7jmSft8c4BoeE8z06+SGIAhU42hOmaj9bhYaQC2jLC/os1QSx0HQkiYEQdx2+quN6ZRfVk1fbkin5yZ3JTU6kVdO9RqiqJAAmjowSQRBaw7nUl29hvw4NQQA4Mb2ZxWLc1xiVLAIgNjkni1p18lz9NWmdHr8lz3U6cEISmkRRh4vLEz5bWVmmoXhi3Bzn5Mu8Pl9v3796IcffmjwvWJjYxt9PA5Q+GKfy9I4i8T/Ns2u8GNwidybb77Z4OulQIb/PykpiT7//HPRcIG/hr+XaUme4c/CP4f0/a2Vw23YsMHqz8DZHnM4e8Kd7rp2Nb5e4Z/TWtkaP28LFy4UgSRnXPjnefrpp8WaHwkHRpxN4jLAkpIS8TzwuizDbcyx9ru0to29z5scEASBKpsiSH8AtprQPYFeWnSA/j11jk4XVVDr5qF2P/7povMiAGK/7Mikx8Z1opBAkzttKnBE1xmuY3w4DUiJpohgfyosr6bdmUXULzla6d0DAGiSvbr1QD1bG68NnTmxsyiT23GyiO79fictuG+YKs/RIC/OQMybN0+sd+EOdI7gjMZ9991ncVE/PwY3AuAsBgcVpjhQ4DbU3FGNS7xYY2tjbMXlcNyIwBFcNjhgwAA6fPiw0ee5hI9bWzcmODhYZHq4ZTb//IZroCRhYWHijddWLV++XDRL8BRYEwQqbIpg/0kuLjKYBqZoA4Cl+8469Pi7M7U16Kykspb+2K3ONpAXgqAICvDzpVGdtB1guCQOAMDd7dGtB+rZupnR5/l899GNfalFeCAdOltKzy7ch0GqXuCmm24SGQ8u+eKMSXp6ushQPPzww3T69GmbvgeXfuXl5Ym2z+bcf//9omECZ4t4sf6JEyfE+hoOnng9jNSVjruYcWkeN3fgJgly4CCEu69Ze7OGu+pxkMgZKt63jz76iBYtWiSCPsmtt94q1t5IeG3P/Pnzxc/JzymvJ+Ksy5NPPqnfhgMebhDBzzevGeLmFLx+i8vmPAWCIHDrpgiGJuu6xC3ee8ahr9+jC4I4s8K+2azOSeWGQRAb01kbBGFeEAB4Uiaol0kQJK0B/WBqH9EUZv6uLKObV+CZuNU0d4Vr06aNWPDPpV4cnHD2xNbMEGd3pNIxc7gcjBsxcMDDTQO4zI2DLG7xzOuX+I0bNPDaIf4/Xn/z9ttvkxpwIwRe/8MZGl5Xw5klzupwO28Jr1sybGjAZXDPPfecKKPjr+dAjDNb3P5bUlxcLIJDLiXkIIq/HweGpqVs7sxHo8arPBtxjSIfoPyLcjRFKheOoHkBF6drDRf8ga3Pn4Z6zvpbtHpe9shF1DnB/t8nz5AY9PpKUUu+4cnRlBRtX0nctXP+EWUWz0/uSm8vP0SVNfX0671DRMmZmo6ZEW+toVOFFfTTXYNpSLsYOldRTf1eXSnWBDnyc4P7wHkGPP2YKSqvpj6vrBAf73lhHEWFmr/guu+HnfTXvrM045KO9NCYDuTu+KKU77jzegtrQy5dgS8LuXEABwz2lqaDd9K4+Jix9vdiT2yg/jMieAVej8MBUKCfL7WLdWxWQWxEEA1OjXFoZlBNXT3tP6O9+ziyYyxd2VvbreWbf5TroGNORXWtCICkNUGsWWgg9dMNjEU2CADUZntGIZ0ssG0Q594s7Xk4JSbUYgDEhrZrId7/c/zCMEsAAHsgCAJVSMvWvvB1TAgXdd+O0g9O3WtfEHT4bKnI/HApXGqLMLpliHZB4bL9Zym3xGQqt4KktrFcEx8THqT//NguupK4Q1gXBADqweVqUz7dTLd8uU1k/Buzz8J6IFND22lveHHHOB4bAABgLwRBoAoHdOuBuiUadwOy1/huCaJWfF9Wsc13HplUV8416L6+PtStZRT1T24uWnb/uO0UqQUHa6xDnPG8hDFdtD31t5wooNLKGkX2DcDd8Q2PLzacoBL8Dclm3vZM4qJ7zmBLWR5r9ljoDGeqbYswSogMpuq6ejEoGwDAXgiCwCOaIkg4OyKVSdhTEic1ReiddOHu461DU8T7H7eeEuVyanBUlwnqlGAcBHEJIV8U1NRpaMNRlIcAOOLjNcfo1SUH6bvNJ/EEyoAzNIv3XGhUw5n1xnALbNbL4FxsDq87kLJBm47hnAcA9kMQBOpqj93EIMjRkjh9JsjghZezSi3Cgyi3tIqWH3Cs7bbTMkG69UCGpC5xKw/muHy/ADxBeoF2vR23X4am4/NmaVWtyM6zZfuzrXbczCmppJySKrF9NxteC4a2l9YFFXjMr8uNe1UBuN3fCYIgUBwP+swu1q676WyS4XDEpd0SyM/XR5TYndJd1FjD5WPH8soaZIIC/X3pxkFtxMff/mP9znBxRY0Ius5XO7c2/aiuPXYnXXtscyVxaw/niU5xAGCf7HPagYXHdRlXaJrfdmpnuNw2rK04n2YUVNCRnLJGM/Lc/j80sPFZ7twdU8oeuXsJo5+fduhrdbV2YDcAWFZRob22a2q77sbPMgBOdlCXBUqOCaWI4Kb3n48OC6QBKc1py4lC+jvtLN15UarV7fedLhY1662ahYgOc4ZuGtSG/rfmGG3LKBQle+YyVf+eKqIHfvyXss6dp8cu6UgPOqldK7/In9EFix3MBEH9U5pTZLC/CCp3ZxZRv2TntPYG8FTSzZgT+WViET+vDwRHn8vztFFXpnbrkGSxRpMHOnNJnGk5r+l8oMbWA0n4nM1d5Di42p5eqL8R5I64tTDPw+GBnnxhp2Q7c7TIBrUeM/w4HABx23+eaSTdPHAUgiBQz3qgRPlmPV3SNUEEQSvSchoNgv41sx5IEh8ZLDJLvL7ouy0ZNPvqnkZ/jF9tyqA3lh4Ua3EYB0vOclR3B5UXA0eFNAwWuaveyE5xtGjPGXGxgSAIwL6bDNymn3GnSL6pgZlbjuNBpnxzaWDbaEqOCRPnUREEHThLD481f6Noj42d4QwNadeCMgpOiZI4dw6C+MIxMTFRzD45eVLZNWn82sbzpTgQw5wgUOMxwwFQQkJCk78PgiBQ3AHdfB5basBtNa5rPL2yOE3Mp+Dhe83DAu1qimCI72JyELTw3zP09PguYnZF8fkaevK3PbT8gHb9DXeS40Gr/L34ZOCMk8CRHMvrgQxbZXMQxPOCnhrfWfZ9APBU2eeMW+EfzytDEOQgPgf+riuFu7Zfa/F+bJd4UabMmX/OCnFgZPo13NVT6tJpK26O8NM2bRDk7gIDA6lDhw6Kl8TxxWxBQQHFxMS4xYBdUF69C48ZzpQ2NQMkQRAEHtUUQcJ3cHl9ES9wXn0ol67RvRCb4hdeqSlC7zbmX3j5Tqb0vX7dmUmD2sbQfT/upMzC8xTg50PPTepKUwe2oe4vLaeSylpRmsGd2pwVBJlbDyQZ1TFOXGhw3X1mYQUu4gBsdKZYux5IcjyvnEZ1wtPniF2nztGJ/HIKCfCjiT20jWr4RtTg1GjadKxANEy4e0Q7o6/hFtrnKmrEwGxL5XLmSAOyObjiUmAuh3ZnfAEZHBys+AUtX2jyfiAIAk8+ZtxnT8FjW6jyxQbr2sQZQeayQYxL4qytAeDubxw4dG9p/vE5qyMNT/3f2uN0zZx/RADUunkI/f6foTRtaIpY9CtlsqQWr84KgnjRsCWcpeKsFEOXOADHM0HSYGJwvCHChB4JFB7kb9Rx01KrbGk+UJfECHE+tRWv45RuDPGcNAAAWyEIAkXxhT13MuO7d/GRxk0J5FgXxNYfzbM4UVwqheMX0ZBAy+nVK3u3oghd0wEezscB1pIHLzKqXZdKOKTMktykrkodG7lLymUnbNXBXKfsB4AnOqPrDCett+NyOGjabKDr+iUZ/d84XRDEmSJuh21ob6b964FMu8T9cxzzggDAdgiCQFGHskv1d//kXkfTvVUkJUYFU0V1ncUXR3PzgcwJC/KnR8d2pOahAfT85K706S39RNbFUK+kKKMOR3LidU15pVXi4w5xltcEsTFdtPOCNh3Pp+lzt4nafHdvHwvgqnK4Ye21F9QnEAQ1aTYQZ8oHtY1u0Gimr67s+G+T2Wv2doYzNMwD5wUBgPMhCAJFcR04c8YaGg6qpKzI37oGBpaCoD6NBEHs9uFtadfzl9Adw9uaDdikO5jc6KGmrp6cUQrHFxYckFmTGhtOl3aLF52ZeGbQY7/uof6vrKS7vt1Bf+45Q+W6DlgA0LAcTrqgzi+rpnMVmNniaCncNX1bm20xPr67NhskNZVhXA2wX9cgp7EbUpbWbfJDncgrp7O6NucAAI1BEASqCIKSmoc65ftfolsXxK1Zee6HIX7hlboRWWqKYMpatqptTJgomeP2ulLQ4sqmCIY+vaU/rXpspMhetY8LFyV8vDbqoZ/+pX6vrqAHftxFm48XYDo5gMFcG9Y+NlxkkBlK4hyfDcRBkDncKpttPlGgDzJ5/RVn7EMD/ahdrPVMtzlcwtijlTaDhJI498LNiRxx+GwpfbHhhOw3HMG7IAgCRWUWaYOgNtHOCYK4c1BEkD/ll1Xp5wEZBhb8whvm4AuvKb7rKZVyyF0SJ60HMjck1RL+mXgex4pHR9CyRy6i+0e3EwNpOUhbvDebpn6+hcb9dz19uzmDSlEuB15+ISYNSm3ZLER/Pjieq23aAvbNBuIyuDYx5s/p3Bq7S2KkuAnFN6cM5wN1bxUlmtQ4gucFMZTEudffHb8OjX9vPVXVml+3a8msRQfo1SUHzTbZAHCLIIinyz733HPUtm1bCgkJodTUVHr55ZdFqz3wDtzGmTlrKCF3GRrZKdZslzipKQKXsTn6wmupJE763nI5LGWCEuwP1jh71Tkhkp64tDOtfXwU/XH/MLpxUBtx1/Vobhm98McBGvz6Knpu4T5xdw3A23DDk6raeuJEL69b4ewpQybIvgva30xmA1nC5bpMuoDdp7tp1MuB9UCG84IYMtzug1/XeKg5j5+w94aD9LfprG6s4B0UDYLefPNN+uSTT+ijjz6igwcP0ltvvUVvv/02ffjhh0ruFrgIr03hunvmzMnsUkncijTjO0aNzQdyhNQhTmr3KtfFxVFpUGqc7ZkgSwER19y/flUP2vLMGHrpsq7ULjaMyqvr6Pstp+jS99bTzV9sxVoI8CpSFqhFeJC4ccJ/EwxBkO12nSqi9PxycXNFmg1kibQuiDt38uuAdCHrSGc4Sf+U5mJuW9a58/oya1A3XrMqsed3xh0Ic0q0jYL2Z2nnDAK4XRC0efNmuuKKK2jSpEmUkpJC1157LY0bN4527Nih5G6Bi5wuutCSVmpL6wyjOsWRv6+PmEdk2PFJ3xmuCS+8pqQOcVxqd77avvS+JXllVVRUUSMW/kp3qOUQGRxA04e1pZUzRtKPdw2iiT0SREaMa/o/XX9CtscBcJf22C11a4GkcjjMCnJgNlD3xEabt/DaxpSYUKqu1a5VPKjrEtqUc3FooD/1SdLOSENJnHtYezi3QVWILU7ryuilRkSOrisCsH6mcrLhw4eLTNCRI0eoY8eOtGfPHtq4cSO99957ZrevqqoSb5KSEu0dAC6fU7qEjh+f/xCV3g93crJAG5AkRYc49XmLCPKjQbpJ5dyW9e4RqeLuo9RsoFfrSNkePy48kOIigsQA1n1Z5/SDS5tyzBzOLtGvmwr083HKczW4bbR44/KU+378l37ceoruH5UqLixAPXCecW4QlBAVLJ7jti1C9Xenz1fXUJC/5RliaueKY4Zv+Czaky0+vqZvS5sea1y3ePpsfTp9sOqoaNzSLCSAWjULatJ+Dk6Npm0ZhbTpWD5d3996SR4oe8yUVdXSjowi/b8zCsptfryM/AulcyWVtZRZWE6tndRcCdzvtcmefVD0Cuepp56i4uJi6ty5M/n5+VFdXR299tprNHXqVLPbz549m2bNmtXg83l5eVRZWan4k84/Cx8Evr7oN2GLtJPau0Bxob6Um+vcwZ5DkkJFEPTX3tN0Zedw2nW6lLhZXFx4APlUllBupXwp9U6xwSII+ufgaWoTUtPkY2bXce1apuRmgU5/nnq18KFWUYGUVVxN36w7TNf00q6nAnXAecY5jp3RzpdpFqDR/o1pNBQW6Evl1fX079HTlBoTQu7KFcfM6qNF4qI2MTKQUsJqbTpPDUwMos94HpPugrZTbIh4LW+KrjHan2/TsTzKycmRffact3DFMbPu2DmqNejYevzsOZtf39JOGW+36WAmjW5v+YYjeNdrU2lpqXsEQfPmzaPvv/+efvzxR+rWrRvt3r2bHnnkEWrZsiVNmzatwfYzZ86kGTNmGGWCkpKSKDY2liIjI0npA4BPuLwvSh8A7uJcjbaVavvE5hQXpx3w6SxXDoig/1uTSfuyy8k3NIpOlWmzUH2So2V/7IHtSmjDiWI6fq7O6ve29ZjJrtCe8Hu0iXH688TuuOg8vbz4IP22r4DuGdPV7KwPUAbOM85RXHNGvG+XeOF80D4uQqztK6oLcsnfnTsfM7s2aNdbTujRkhLitWswGzOqhYYSlqbTWd3ajv6psU1+nkdFt6DghceoqKKWiimUOjZxDaW3csUxs3uT9nWtU0KEaMhztqzW5t9/UY3xUNysch+3/hv1BPUqugYODtaWNas+CHriiSfo6aefphtuuEH8u0ePHnTy5EmR8TEXBAUFBYk3U/yEK/2kMz4A1LIv7iBTtyaoTXSY05+z1tFh1L1VpFhEueZwnr5xQZ82zWV/7F66unSeQdTY97blmNHPCEqIdMmxNWVAG/rviqNikfP6Y/l0cWfbLmrANXCekd/ZEl177OYh+r+xdnHh4jzBAzjd/ZzuzGOG7/yuP6K9oTW6c5zNj8Gb8cygbzafFP/mhi1N3b/gQF8akBJNG47mi65jnRMd7zbn7Zx+zBzVHjO3DkmmZxfsFw0tNORjU6fWzELttUOHuHDR4TQtu9Tt/0Y9gY9KroHteXxF97SioqLBznJZnBpqCsH9ZwSZuqSLtiMRL8Td44SmCBJpVlBGQUWTu6xpO8Nps1Yd7ZgR1BThQf50w8Ak8fGXG9Nd8pgASjpzThsEJUZdKHvTzwoyaKYCDaVll4jy35AAPxrYNtqup+hSXZc4KQiSw1AnzgvirmRYhN903HCEg54gf1+6sncr0dWvpo5ndWmDm8ZITRQm6I6f/bqh5wD2UjQIuuyyy8QaoCVLllBGRgYtWLCA3n33XbrqqquU3C1wAX4hkVpiuiwI0rXKXnckj84UV4pua1LAIqdmoYGi85EcQ1O5dW9pVa3obte2hbZtryvcOiRFPD+8jurQWbQgBc/FQztzpExQs2AzQRAGptrS5nhY+xi7G0gMTImmST0TaerANmI+kxykeUFbThSI361cuI13txeX08uL02T7nt5+zAxKjRGdBKWmBra0yTa8dhjXLUHM9uIgPK/0QtMsALcIgngeELfFvu+++6hLly70+OOP0z333EOvvPKKkrsFFtTXa8SdMLnaPlfWaIcT8oR2V+iSGEGtmoWIO05SZqWxVq5KD02VSuE4AOL5Ja7Cc5ukWR5fIRsEHiy/rEos0OYynLiICxfihgNTcfffsnW6C9qRnexfk+Hv50sf39iXZl/dg+TSrWUkRQT7i65hcmYIOLPEQdXcTRn68QrgGL4RyUZ1jDWaE2hLm2yeLXi+pk5cO/BruHRzkFtlA7hVEBQRESHaYfM6oPPnz9Px48fp1VdfpcDAQCV3Cyx47a+D1Pn5ZXTnNztoR0Zhk54nqaa3ZVSIyy7uuV5VygY5qxTOtLSjqUNTpSCoY4LrF/jeMbyteL9w9xlxoQjgye2x4yOCjNYjJMeEigxsRXWdfpgqGCs+X0M7TxUZXdAqjQOrIakxDYZxNlWWbg0re+nPA+KmINiPx1NsS9deP4zspD1mknVB0MmCxoMgKQskXTt0a6mt5jhwBhULYD+sJAObVFTXitkxbOXBHLr2k810zZx/aPmBsw69GEh3fHhGkCuNMwiCerdxYhCkK7Pbc/pco3eR+SKMXxjMOSKtB1Kgy1HfNs1FMMcDDb/fol28DOBppAAn0SQjHeDnS210Za1YF2Qez+Ph7Ei72DD93Xw1GNslXv9aJXewzDgTtODfLNm+tzfZfLxAzIXi1/5UXRZHKom3pRzO9Nqhe0ttZ2BkgsARCILAJtxMgFPQrZuH0NSBSRTo50s7TxbRPd/tpLH/XUc/bztlV6mc/kTm4gFnA9pGU0xYoEilD0hx3lwBvjvFd5W5TlnqPGXOP+nFNOLttdTnlRV0x9fb6ZftmVRgkHW50BlOW5rjSpw5k7JBHATJVQoJoCbSxW1iVMM1Kfp1QblojmDO2sPaNsejHCiFc6aLu8SJczx36LR1sX1jeCG/4ZqjN5YdErORwNFSOP4d+dhdDme6lhiZIGgKBEFgkz93a+doXNWnFc2+uidtfGo03Teqnai95hayT8/fRyPeWmNzDbarmyIY3t397o5BNHf6ADEHxFlCAv303dz2ZJp/TjioeHvNKTG0lbMtqw7l0pO/76UBr62kKZ9uFp3ZpM5wHVzUGc4Ud9/hi0Ouw/5zj/YYAPDEznDm1iZeWBeE5gimOMMtlZuN0pU1qUWL8CDq10Z7k2tlWo6sQdAzE7uIxjd8g+uj1cdk+d5edcwc0QbOIw3KJ7n0lJ10KAiK1JfSlVRaHk4OYA6CIGgUt3lef1T7Ynd5r5bifVxkMD05vjNtnjmGnpvUheIjg0SHloU2lghIJzIlSii6tox0yZ1Lw5I4c+asO0HZJdUiyPjj/mE045KO4oTOQRHXTL+yOE1k37juWaqZdjUOGrlTnNQgAQvEwdNImQJrmSBu6QvytcZ2hbG60ue/ZQiC+OK6tFKb9UlpEUbPT+6qPydm5CNAttWJ/HKxHpgrSYa212bUDK8DzlXUiHVm9lw7NA8LFA2PWBrWBYGdEARBo5buPys6qnVOiGiQkeCZMndelEqPjesk/r3fxg4tp3WLTNVUR+6s5gjcWtXUyYJy+nT9CfHxsxM7i20fGtOBljx0EW14cjS9MLkrDWobLdpUj+0SJxb7KuXGgW3Ehc6hs6WinhvAk3C7fNMZQRJe68KwJqghKQvE5WH2tsZ2BakJDrfKbmqGIFuXLYwKCRCveRd3jqMRHWPF2pZXl6Bltr2dBDloDg280JmVn1MuU7elJC7TTBUJ39hkaI4A9kIQBDaXwl3Ru5XFbbpLHVqyShptlMClX2d0d19dXQ7nStIMor2ZxQ2ek1mL0sTzMKBNhH7gm4QDw9uHt6V59wyhg6+MFy1klRQVGkDX9mstPsbwVPA02boyJ8MZQZJ2unI4znig1Mb8Ba3aSuEMs3ipsWHiBp60r47KOqe98JYyDryWhW9UcffAlQdz9etcLDlbXInjhwNn3fNkWAonsWVdEJeQS2tsDa8dpJI4NEcAeyEIgkZP3lvStXf/L+uVaHG7DvHhIsXNgz0ziyoaXYjMDdM4u9Ai3HPbofOaoOAA7XOSXnChZIJr1FcfyhVTsh8b1Ua/ONQcvsNq7f9d5bZh2pI4Xrd0Ig+lQeAZ+EYEzyyztCYoMjiA4iKCxMe89hHMtMZWWVMEc9kgbuzTFFlm1o3xerFpQ7XnxZcXHaCauvoGX7c9o5Bu/3o7DZ69im75Yit5s/PVdSIrZylwtmVdUJbu2iEs0I+idZkj05uwAPZAEARWLd57Rpx0+iU31091trR2pHOitlRufyMnogs1vSGquMB3Fn5OpM410tBUvpP10qID4uPbh7WllGh5pqQ7W2psuCgBYb/uPK307gDIIqekUpzfeN2dVI5jCuuC3Kc1tqWRCGsO55oNUuztINjKJFvIJcx83HDjjG/+yRCf43WTqw/l0LVz/qHrPtksbnhJM+NKvXjhPt9M5ZsOLaOC9Q1HDNnSJttwPZDhtUO3VtpM0LG8MnQxBbsgCAKrFuk6gkkNEayRUtKNrQtSqjOcoiVxuqGpc9YeF+uheBH2A6PbkTvhzoBs2f6zaJAAnjUjKCrY4g2ZdnFYF+QurbFN9U5qLqoNuKmBNKCzSUFQc+NsIa8ReuJS7XrY91ceFaMiJry/gW7/egftOFkkqiOmDmyjz1p4czZRKkkc2elCa2x7y+HMrQdiCZHB4jnmwPzwWe1YCQBbIAgCi7jrDd+94nk3E3tYLoWT2NqvXyqXs5ZZ8hS9dc0RuEPcqYIKmrPuuPj3c5O6UljQhYWh7mB05zhxxzw9v1w/xBXAUzvDSTAryBhnOvSzXlS6HkjCr11SBrspJXFZukY+5komr+ufRN1bRYqyZx4VwQ1kuFzrnhGpYpTE7Kt7UAdd5uNEvveeNy8EzuaPGakDKre6toRfQ80FQRxU2XoTFsAQgiCwSJoLw91/YnV18dZ0byXV5RZbzRRYupvjiXq2bqYPDJ//Y78oBxjWPoYm9jBuhuAOuIPPiA4txMdL92crvTsA8s0IMtMZruGsIO+9gDV0MLuUckrU2xrb1CVdE/RBkKMt/qVMkLkgiAOtWZd3FzeIOBvx+LiO9M/TY2jmxC5ilIRUTuzNmSC+oZpRUCEaSUjDZk210a0J4nU/tRZKF/VVJLptDWFoKjgCQRCYxS8Wf9pRCse4hTa/IBSUV+s7uJjDcwKYmmvJ5cJD9SKD/UXww3dPuRkCv2C661qo8d0T9SVxAB6TCTLTGc40E8R3qJuyrsRTSMMu1doa29Tw9i1Egxq+uObZRvbiC3Lp9ay1mSCI8ZrZLTPH0D9PX0wPXNxBdNQ012rdW4MgKXPYP6U5RQQbPzeS+IhgEUhySZtUpmrPfMELHeLQHAFshyAILN7t4wGBfFK61KSFsyXBAX76tL+15gjetCaIgx1pXhDj1tfmFoW6CzGzyNdHlHxwWRyAJ2SCzM0IMlxvEBroR7X1GqulOo7gCz4eivy/tcfcZp2dNB9I7aVwkpBAP7qoQ6zDJXEcAPGEA76B1SLcckUEZ4H4NdAcbtXtzdlEqRRuZEfLa8h8fX0oSbfmylxzBP77sFZFIlWiHMousZhJAjCFIAjMkrJAF3eKE21ibSWlpPdnFVtsrSpNhObucN6gl64kji+mHrq4A7mzZqGBNERXzoBsEHhKJsjcjCDDizNnXcSuOZQrZm+9teww/bw9k9yiNfZJ9bfGlrNVtmGgzMeCI1JbaG98ZRSUNzpHz9OUVdXSZiutsQ1JwY25mw2F5dVUXl1HXEQhzWsyXVPEJdtVtfWiWx+ALRAEQQN8ktZ3hettWymcrUPLpDs53LHHcGK0J7tlSDJN7plIH9/Ux+2aIZgzXpcZXIZ1QeAx3eGs35BpryuJkzsI+nHbKf3HL/5xgHbrWumrvTU2B4XuVM48pnMccfzCpVJcFudYe2zHb9q1bh4iMkmVNRcGhXuLD1cfFT93aoswUTJvjbU22Zm65hR8M9Fcxo0D1C66MR0Ymgq2QhAEDew6VSReKPiuitRZx1b65ggW6nKlIMidXkCbKj4ymD66sS/1S1b/ImJbjOuaIO7GcedAey8oANSCZ3bx3eXGGiM4a1bQ6aIKMb+GDUyJpuq6errv+51UoBvequoOX1bKmtQoJjxIrNuRhlXbI8tKUwRb+fv5UnKMlE30niwFD9b+amO6+Pi5yV0aXQtrrU22tfVADStRsC4IbIMgCCyWwvGgOUs1zpZ01WWC+A5rvpkXc6k9tjesB/JU3ClwQIo2oENJHLh7FojX+0SGWM/QttN3iJPvAvbnbZliUCsv3P9ien9xp/xMcSU99PO/qlzTYNgae3Rn91gPZGhsF21J3MqDjgVBpoNS7XWhOYL3rAvi9W41dRoa3SmWLu6sff6tkQLFk4XlDnWVbawSBcAUgiAwwi++S/ZmO1QKxzh7xC/mlrJB+rs5XjAjyJON76YtiVuOLnHgprJ1F7fWBqWaZoJO5JbJ0sCAu8xJa4BuHNRGrLv85JZ+ou30pmMF9M6KI6Q27tYa29K6oC0nCqikUrsutSmDUu3lbW2yVx/KoTWHtR1Rn5/c1aav0ZfDmVkTZGlGkLlMUNqZEq9bewWOQRAERjYdLxAtrrnTzbD22pkw9urWynJzhFO69tjIBHnGuqDtJwspt9RyO3QAtbKnzCmlRahYU8IDMfNKm16uxgv0OVPOWVXp4rxjfAS9eW1P8fGctcdVl2Xl9UBsiJu0xjYXhHA2hjMTUoe7pg5KtevxdTcHvWFgalVtHb28KE3fEVUKABsjNUsqqayl4ooau7vKdogPp0A/X/F3KlWdAFiDIAiM/LlbWwrHwzwD/Bw7PLpbSUmf1p3IWntJZzhPxRcE3Pqbb4r/fcDxSewAyjdFaLzMiS/6pYsvOdYF/bD1pHh/ff8ko/Msz2S7fVhb8fHjv+5RVUvl3afP6We9uCvDwam24KyftUGp9vCmTNBXGzPEcNS4iCB60I6OqNwsSRrMbtocwZY1Qfy31EnXfAHzgsAWCILAyNZ0bSvLCbqhmI6QmiOYLk7krkKndXfVkAlyfxP0XeLUdccawK5BqY00RTAtiWtqYMLztbjkjSvwbhiY1OD/Z07sLBolcGvhe7/bSeVVtaQGe3VBkNTy3x1JWbe1h3LFAOvGlJyvFW2Zm9odznBNEAffFdXq+J06w9niStERTjqWuUTeHvo22Qbrgvh3Jf29NnbtgHVBYA8EQWAUpPAJjLXVpe4dIZ2E+M6NNBOI5ZRUig5IPGzT1gsPUP+6IJ4Bca5C22ULwF1I81+szQgy1xxh0d5s0VnOUT/p2mKP7hRHrc2sjeS72R/d1EfcRT+aW0ZPz99HSuMuepm6UmbpJpc76pPUTIxn4HIp6YafNafPabMPMVYGodozY43LzD09G/TG0oNUUV1Hfds0oyt7t7L76821yeZsHC/x4fVo/PuzrRwfHeKgcQiCQI9bs/JUdK595xfgppzspbtmvEDRtLsLLzD1c3DoHKhHim7uAwfPjgwhBHCnTNBVfVqJi7Bt6YV093c7HQqE+Gt+3aFriDCwjcXt4iKC6X839RXnYp7ZJu2r0lkgXtcSFWL78Gy14VkyHHwyzsbZHijLc9PuwrogzwyCdmQU0sLdZ0SWc9bl3RttOGItCDJsk224Hqix73khE4QgCBqHIAga1MjzCzDPNWiK7q0arguyZWEjuBepbBIlceBusu3MBHVJjKS5tw0QgdD6I3kOBUL8d1JUUUMto4JpdCMz2PqnRItmCWq4q70nU3se79nafbNAkt5tmlls3OOMQamGeMisp7bJ5pthL/55QHx8w4Ak6uHgsaIvhzPoEGfLeiBJl4RIcfOAG4/klqBpD1iHIAga3hlt4jwE1l0/tKy4wcRncyUg4N5d4jYczadSO9rOAiiJj1UuiWL2lOYOTo0xCoTu+naHXYGQ1BDhhoFtbMqGS3PXbLlgd8l6oCT3XQ8k6aErl9qXVdxou3M5BqV6S3OEedszRfYlItifHh/XyeHv0yamYTmcLTOCJCGBfvr1e7sztcctgCUIgsChbkk2N0cwUw6HTJDn6BgfLko8eK0Xz4QAcKdzXWSwP4XZuXCbA6GvdYEQB/+2BkJHckppe0aRCH6uH9CwIYK1m0lKlvZwoLDntJQJcv8giLuH8ewaXq8qNeppPAhq+muinM011HhT4e3lh8THMy7pSDHhjpfTJ+sCHc7C8Twt4yoS24LRvm20HQwf+3WPfu4hgDkIgsBMENT0u17ddOVwfLKXOuGgHM7zcH22lA1ath8vNuAemtr2eJADgdCPW7UNES7pEk/xkbZdVKuh0xW/LnBpETe0kfbHnXG7c6nMkLNBthwnrZs4KNW0HI47BMoxdFct+G+AyzyTY0Lp5sHJTfpe3CI7yN9XNEKQnn/9tYMuS9SYx8Z1FI0ZSitr6f4fd9EzC/Y1qZkJeC4EQeCUTBCvK+KTGZ/nD2aXGGWCpIFo4FnrgtYcyqPzunayAJ5+rpMCodDAC4GQpeOfbwT9vuu0+PjGQZYbIlgqh+P95cY1StijKyniwKGpHdLUQlrb1FgQJNegVAlXQXAwyd3TznrQepUtJ7RNJrjphKPzBQ1vrBmuC+Jg8VSBfVUkcZHBNO+eIXTfqHaiSQPfgLj8o40iGwtgCEEQ6GXr7rokyBAEGQ9NLRF3YXJ1k9ZRDudZuAkGLxw+X1NH646gJA7c51zX1ItbDoTmTr8QCA14bSXd+c0O+m5zBmUY3O1fvCdb3JXmc9/w9i1s/v4RwQH6cQVKlcRJpXC9kty/KULDWXaWg6Cq2guvWXIFQRwgSK9/nrQuaOuJQvF+UNtoWb6fYZtsLluU1u/Zs56Yn+snx3em724fRC3Cg+hITpkIhH7edsqjsnDQNAiCwCnlcKYvNKeLtHdyeNGkO7dYBeslcX8fwOBUUL8zunOdHBe32ozQQIqPDBIDTlcezKHn/zhAo/5vLY14e40oxfl8wwl9FojbNNtD3xxBoZI4qSmCJ6wHsqc5Qk6xNgDi0iyeEyQXT+sQxzOkDusyLAPlCoJ0ZW9cPSKVwvHflyOZyOEdWtDShy+iER1jqbKmXszdeuCnf1UzhBiUhSAI9O0teZipXOVwrJu+Q1zJhRaXzRvv8w/uO4l9zeFccSwBuMeMIHnOdXzxt/npMbTogeH0xKWdaHBqtFh8zwNGuRSHh57yv6/r19ru761kc4T6eg3tkzJBHhQESc0RzlVYbo4gDUrlLLecr1lSh7jjHpIJ2qYbOstNcprSEMGQYTmcHGuJuTT/6+kDaOaEzqIckZslfLEhXZZ9BfdmX1sc8FhyDUo1NyuI63CP5WrveqEUzjP1T24uMny8OHbXqSIakCLPHUEAZ84IkivrzTjDw7NR+O3+0e3Fneat6QW0/kg+7ThZSBN7JDp0kahvjqBAm2we6smlSMEBvuIi11NIzRE4sORKBXPzZ+QelOqpA1O36EvhYmT7noblcPbMCGrs7/Oekdo1Qq//dYjSspVtOw/qgCAIjMpD5BiUKuE7aM1CA8TdtpUHc8Xn0BTBM/ExM7pTrJgWzuVACIJArbj86UyxvK2PzeHW2xd3jhdvTSEFQRkFFaIVMa8TcnUpHGf15XpdUFNJHAdBXBI3oYe2uYszB6U2nBVU5lFNEbh1vFy4y5y+HM7Opgi2timX2p+Dd/Ossxo47KyMg1IlXEIglXJsz9DeLUImyHON6aK92FuZlqP0rgBYxDdleG2AnE1gnImzRy11+5nm4pK4vfr5QJ7TFMF0zaqlDnFyd4YzXRPEF+Hu3rb5XIX864EMGyBwFlI6BuW6dmila3fe2Iwo8A4IgkD29tjm7mJKa0+bmtIG9RrZKVbUW3OtO8/BAFAjKQvUIjxQlEW5g67S+koXB0F7dJkgT1oPZNocYb+F5gjOyhZykwUe0ssPmVHg3ufJbemF4udoHxcu1t3IhRsgcCMElqYbsSFbEKQLavlmCDcyAe+GIAic0hlO0k33QiNBEOS5IoMDaFCq9m7gqoPKZoOqa+tFa1UAS2s95D7XOZO0vtKVQ1Nr6ur1zRh6JXleEMTNEfimDa9jNFcaJX1OyhzIWSHRLk7XHCG33EPWA8m/BjQ5Wpsxk8gVBHE5qdShVsr2gfdCEAROzQRJs4IYL0iUu74a1GWMbv0DrwtS0pRPN9PwN1a79KIRvLMznCvoO8RluS4TdPhsqbiZwFmLFN0aDU/C2QZujmBuXpBYN+akNUEstYVnrAvixh9Sm3i5Gd4w5TblcmaaWusC2yxdB0DwXgiCwGh4oNx3R1NiwigsUFtykhAZ7DETx8G8sbp1Qdsziqi4okaxOvXdmedEPfl9P+xySUbofHUdfbkxnZbuy6b8Mu18EVAnZ3X9cqZuukzQsbwyl60j2WMwH8hTxxoYzgsynX3jzHVj+llBjZQN/7D1JL26OI1q67T7oiZ8fpdK1QY7IRNkmPnhj+U8BqXAFuuCAEEQGGWC5D7hc1tKaV4QzwgCz8ZD7riVLs8KWntE2xHQ1aQXZmnOxOO/7nH6hPD/rT1GryxOo//8sIv6v7qSxr67TgzJ/GN3Fp3V/W2BOrhjJohvIPFaEv67OnRWuxDd2fZmem5TBAm3M2f7TDJsUqDM4yKcsW6snQ0DUzPyy+n5hfvpi43ptO5IHqkNNzvi0yq3/I6LlP9vSeoQ54yGSlLjBQRBgCAIjAalOqNlrHQXE+uBvKxLnK4tuqtJHbQ4GAv086UVaTn06foTTh0oOX9XltEdRp6LxUMyH/55Nw2evYpGvr1GDOgDFc0IcqNMEN8F76orLTYt3XJFJshTWWqOIJVJOStbeKFNdrnFGzSfbThB0tzpP/ecIbW2xnZGKZzp9YLc1w76cjisCfJ6CILAaFBqrEwTnw3dPDiZLukaT7cOScaz7UUlcWsP54rF1a52MFt7p5yHU754eVfx8VvLDulftOW242SRWEQdHuRPqx4bSbtfuIQ+u6Uf3Tm8rbjI4r8rzkhxpohvOICy9F2/3CgTZNjSWWpW4EwV1bViyDXr7YFNEUybI3D5m2FzhCxdoOysNayc5eDzApfs5pkpn80tqaTfdpzW/5tv5HDJrZpsTdc2RRisa4bj7HI4OV1ok401Qd5O0SAoJSVF3OEyfbv//vuV3C2vHZQaHynfoFTT4WSf39rfIzsMQUN80cSlO6WVtbRd90KpRDlcl8RIunFgG7q6TytxR/WBH/8VFxdyW7hbmwWa0D1BrHlrFhpI47ol0HOTu9KiB4fTv8+PE92IzpZU0qZj+bI/PtiXtZOy3u6UCTJqjuCCZh8caPHfDJeDucMsJbmbI5xxUmc4CZfYSSVZnA0yxesLq+vqqV9ycxEAVFTXKd5sxlBJZY3+OBzU1jmZIG5hH6pbTyx/OZzUGAHd4bydokHQ9u3bKTs7W/+2YsUK8fnrrrtOyd3y2kGpnvxiB67j5+tDozvHKVISx92sjuVq72B3TYwUN1Veu6oHdYqPEA0LOBCSMzvFjyeVuV3Zp5XZbaJCA+iK3i3Fx7/tvHB3F1yPj4GaOm3WO17GblOuIM1c4zVBzs6w7sn0/FI4a80R9INSnfiaqG+OYBIEccOB77ecFB/fN6odXdYrUXUlcTsyCkWQzF0DnXXdwOfu4e1biAy73DdQWzfTBlX5ZdWqy7CBFwVBsbGxlJCQoH9bvHgxtWvXjkaOHKnkbnlvtyQ3mpsB7lESx3cvnd2UwNDxvDJxkRsR7K+/2xcS6Edzbu4rXky3ZRTS28sPy/Z4XPLH3ed4sN9gK7Xx1/ZrLd4vP3AW84tUkPWOi3BO1tuZ+G54RJC/LtB3bmvlvae1AUEvD26KIOlupjnChUGpzntNtNQm+7stGVReXUedEyLo4s5xdHkv7c2VdYfzVHPu2KqfD+ScLJDkk5v70fZnx8raHptFhviLvyVXtcnmDLQSpeHQOO1RoALV1dX0/fff04wZMyy2QqyqqhJvkpIS7UmrvrSU6s19jZ8fUbDBXYpyK+0ofX2JQkIc27aigurr6sTX8L6I/5fwfoUapHIrKngIgfnva7rt+fP812N5P8LCHNu2spKI91cnP6eAQqorqXVgnXb/rWzbAO+v9Nzz76a2Vp5t+fmVnsfqaqKaGnm25eOBjwt7t+XteHtLgoKI/P3t2ra+vp40NTUNjxlDgYFEAdrBbuL5Mjj+rW7LvzP+3VnC2/H29m7Lxxgfa41sO6xdNAX5aijvbCEdPZFN7eO0JSdG+Pni54Lx3wT/bVhi47aHjmVTUG01dU5oLoIvEYCVl1NKMNE7E9rRI7/soe9WplG/6AC6pFt8k88RSzYfE387V3eMJ5/yMqq3sG23KD/qGeVHR/PKaemWozSlf5JD54h63c/Ex44rzxFN2raRv/tfdmSKC3wRRDr5HJFVVEEBdTWUEhyk/btT+TnC9O++d7Q/7ThZRmlHz1CncB+bzhHiWJFem3h/bThHHD6RLZ6nHq0itV/vhHOETds64RwhGPzdd0+MEH/Dx06cpbqSEnH9UZBTSCHVNdQqoI7q+fs44TqifYSvvu25eI4rKuh8VS39uPqgeOz7BnQgTVkZdQgj6tHcn/YV1dLSfWe05w4nX0cYHTOGr026bTefKBDn2aEJVv6OZDpH8G+03vCQlukckRpKdKS0krJO51FqiPOuI6r9A2nS/zaLX9f8O/tTpJ/GqecIpa4j6nl/zR0zCpwjLB6T5mhUYt68eRo/Pz9NVlaWxW1efPFFPnoavBVrf/QGb+fHjNFkZ2fr3+pCQsxux29VQ4YYbxsdbXHb6l69jLatbd3a8rYdOxpty/+2tC1/H6Nte/WyuC3vn+G2vP8Wtw0JMdqWnxdL2/Kb0baTJ1vd9uzx4/ptK6ZMsb7tvn36bcumT7e6be62bRe2/c9/rG6bt3atftvSxx6zvu3Spfpti59/3uq2Bb//fmHb11+3um3hd9/ptz333nvWt/3sM7EdH+uZ775rdVv+XtL35cewti3vo7Qt77vVbZ9/Xr8tPyfWtuXnVL/t2rVWt+XflbTtA6/Os77t9On6bfnYsLYtH1v6bY8ft7rt4k7DNI//tFW/vbVtm3KOqFXgHFHTurUmLS1NHDs4R9h/jvjvkt2a/w6b6jbnCPF3/9lnipwjXht1m+ZQeqZTzxF8nlfiHMGva9K2GZlZTjtHWLuOKOrSXZP81GLNsNdXNHqOyE1KFdte+/E6xa8jjp08rUl9erFmVWp/q88briO0z8M/c74Tvzt+m3fLYx51jig2uI7IXbJENeeIYik2KC5uNPZQTSboyy+/pAkTJlDLltraeXNmzpwpMkWGmaCkJIM7qiaCAgMpLk67NoFZG7YVYLqtpTvzHHgGBBhvK90RMLetv7/xtlLkboavn5/xtlI0bgbvn9G2UtRsblsfH5u3ZUbbShG2lZJG6Y6Pj+HdMkvb8htva3i3zIyYmBjeEe22hne1zIiOjr6wreHdJ3PbNm+u35bCteUIljRr1uzCthFmMhkGoqKibN82MlJsy3fbShvZ34iICIqQvi8/hhXhEREULm3L+25t2/DwC9vyc2JFWFgYhUrb5lmfVxEaGkohum1HdU60vm1IiH5b/Z09C4KDgylI2tbanVidvqnxRsexM84R1fVEfi4+R/j5+Ynjkv+WfH19cY6w8xxRWl9A1v861XWOEPhjBc4RzUMDqEOblk49R1jN1jjxHBEUFGTT+cGZ1xFhwdrX4TMlVRQVHSNe/y2JCtVuuzOzlHxCosQ5Q6nrCJ5ZVKchCmlk8DmuI7SOn7uQqdp3tpymeNA5ItzgOqLeDc4R5vhwJEQKO3nyJKWmptL8+fPpiiuusPnrOAjig6b4zBmKNHcQuLgcLi8vT39x4k7lcGPeWSvWBf141yDq06Y5yuFcWA6Xe+YMxUVFGR8zHlAOx84UltOYV5eJw3rDk6MpxrT9usylLnwqG/rGaiqsrKPfHrlYPwjR9G/58V/20JJ92fTEpR3p9pEdHD5HTP9wjWgT+8jYDnTPyHZWt5X+7v/z/U5aeziP7h7Rlh69pJND5XC5ZWXiAkMcM25eDvf8wn30205td72RnWLpk7svcmo53P0/7KK/d5+i58Z1oGlDU9yuHI7bVl/x0SYKC/Sjbc+OFcOobSmH07822VAO98naY/T+qmN0aZ8keu+WgVa39YRyOPbs91vErK97R6bSgJRouuObHdQ+NowWPXSR064jND4+1OPNDVRWVUsrHh1BB46dpZm/76WY8EBaOWOk6Fyn5+NDV879l3ZnnqOXLutK0/vEO/U6wuiYMSmHe2PpIfpk3XGa2iOWZl/Zzbbvq8Ky+rkb0+mt5YfFKIV3pvRyWjncxE+3UVpuBbWPC6eM7HOUFO5Hfz4wnCKCA5xWDvfCH/vp1x2n6cZBSfT85G4uK4fLy8xseMwocI4QsUHLllRcXGw+NjD8clKBuXPnihf1SZMmOfYN+I+tkTvq+u3s+Z624j9KXt/BJzz+Oit3f4xOTo1pJFvi8LYGJ3SeW3Ky0odqA4MpoWUMUZjJ92kku2OED8RGMkcObct/DI1kr5y+Lf9RWrmj5vC2/Afc2DFjuK2VO4BG+ARt6zFsz7a8nzZu2zI6jFJT4kS73dWZ5XRdfyvzJPhFzdZ9sLBtTnElZdf6kV+gP3WIN7iDb7JtXGI0nT9cRBmVPg2Pbxv3Ibv4PK07U0GawGCaNKQ9UVgjf9e6v/vLh3agpemlNC+tiB66PFR00rO0rVn8glBW5tJzhKzbmvzd7yqoofOB2q9febKMCsqrLwTLTjhH8IL3Gr8AikuItu13rZZzhO7vPjU5hOpDQym/tp4yKi90GDO3rZ6l1yYLf/c7db+T7iktGt22qecIu7aV4RxhSed2CXR+f4E4HhNa+oifPzrewjEi03UE/+Xz74+bUHCji4+2nhGPe+PFnSi4WcMLt8t7tRRBEHeJmz6sre374Mg5wsr1zNZ07by1fp1b2v5cqPA6gq93+PlOP69p+HPIdB1xtrhSBEB8OH592wC68fOtlF5YQa+vy6TZV/dwyjmCbwbyuZR/tp8OFNLDVwRSpOH3ceJ1hIZfu2y5nnH2OcJawG367UlhfMeBg6Bp06ZZTfGCew5KBe82RtclbpULWmWnZWs7WrWLDTO+i2pCmj5+ugnTwv/cfUbcdBqYEq2f92GLi7vEUbNQZWcGcUvvu7/doXinqaraOv1AzsSoYHEe4gydM2Wfc88ZQRLuaNc5UXuBvN9JQ1O9qT22pIfuZ+VZQfr22C44RlJbaC/uPt9wQgRC3LGMh4ubM7lnonid3nXqHGUWKjPks7yqVt85cFBb5wxJdRXpvN2U14HGrD+Sp/9b4sd785qe4t8/bTvltPP/ifxyfRdMni/FGSFQcRC0cuVKOnXqFN1+++1K74pXcvagVPBuY7toa3XXH82jyhrnzmM4mF2qH5JqTWsZpoUv+DfL6mwga0MSr+ilXWfxq0Izgz5cfZT+TssR7bqVdOSstp05B4V3DNfe2V6oe16dobaunnJLpXEA7jsTrbtuXpAzhqbynevc0ipxsd29lfW/I0/C7aj9fX1EJnLnqSKj84QzpcZqM9Yc2LBbhiRTpLkyKc5gRwbr2/Av2qvMzKCdJ4tE9UirZiH6m0nuShqEy8e7s16beP0UG9lRuxZ6SLsYunWINsh96ve9IqiU28aj2uAq0F97PffNPxnidwbmKX7VO27cOJG+69ixo9K74pUwKBWcPeWeZ+jwHaktJ7RlFM6Sprsz3ngQdOEOoCNLIg+dLREDKwP8fGhijwS7v/7afkmKzQzieRUZBdp1CofP2tFG1An26y7i+RjhUh/pLvepAufc5c4prRIDHvn31sKNs97ddcM9DxjMtZHLntPai/GO8REUGug9lRmcOe4Qr12IvkU3A6dlM+cHyobljEH+vnRbI2Vul+luoHAm2pr5u07TrV9tozPn5M1ySKVwg1LdOwskNf4IDdRWDGTrbgbLfdNlw1HjIIg9Nb6zCLD59efNZYdkf9wNuiDonhGpFBUSQKcKK2jNIdcOLXcnigdBoCwMSgVn4oXbF3fWlsQt3uvcUqeD2dqLwq6NBEHSxQ0HZkUV9gchC//VXoCM7sSlbTbWjRvgO+yd4iPE0MvFLr6jm11SSZU12kXSUimaUrj0iHVrFSnucg9tp12DsnB3llNv+HDWWzQUcFPdDDJBcvc1ku5c9/SCIammeCYSk+6au2J4uDQwlfH8n8aGgk7oniCCeL4Jc9TM3y8fDx+vOUYzftkjSrG+2Zwh6/5KAaK1wdDugrvdcUarqVUBlvD6rZLKWhGI9E66UFoaFuSvL4v7dvNJWW8OcuAlfb9LusbTDQO0N9y+/kfe48CTIAjycrw2gSW4cXkIqNtVupKx33aedlo2qKK6ltJ1GY7GMkFcksbZKUde/DiT8udux0rhDF98r+vfWv+cuJLhdHq+kFJDENRDl9mQnk8OgpzRtNRTbvhwloZLtziAl8qZ5cCZwXnbM8XHV/Z27Nh2Z9JxaFou5exMEK8D4sDm7hGpjW7PN11GdNBmFbhBgum56dUlB+nt5Yf1n1u2/6xsf0t8jt2ryxQObuv+QZBhyaO0DswZNxQu6tCiQQOcYe1b0NSBbcTHT/62Vzy3cmVyudsglxh3axklyiv5oTceyzcbNAOCIK8npct5YTKAMwxsG01TB2rvSD3x2x6n1EHzBT2/1vOd1MbuphqWxGUW2vfity2jUFx48oXLxZ1tmzNizhW9W4kXxn9PnRMLol0lPf9Cy9680ioqLLfSgtWJaurq6aAuCONyOHZpt3hREnQir5z26QIkOXFHP5bogjInZ5ducbtdw0CyqfhC+aU/D4gsyPhuCTS0vUFnOC8hlRkyvnDkjKErfpc/3T2Y5v9nmM1rbC7vrSuJ23NGH+Dw39Pjv+2hLzemi38/Pq6j+Fs6WVAh280OXg/Ea/h4PV1StHvfSDANdJ3RHMF0PZCpZyZ2Fs8ll6sZBq5ylMINa6cNvPh1blxXbck2skHmIRPk5XghLEt087ujoG7PTOwiSg846OA5E84qhWssC9TU5gjSwn2eLWGtA11jOFAb3Un74vj7LtdlgzjAMKTUuiAO/LgcMCLYn5JjtBd/PDeDSzgMSw6dkQnyhHOdfl2QTB3i/tp3ljafKBAXzs9O6kLeiM8d0h17DoACXNQoiH+X+plmNhjbJZ6CA7QBDndq40X99363U8w54v1/57pe9MDFHWiE7uKbs0FyWKr7Phd1iLU6MNadSDfDsmReO5VfVqXvomcpCOLz3WxdWRwHKIZZekdJHeeGd7hwE2P6MO08ND4+ih0o//Z0CIK8nLQg0N3vjoK68QlfqoP+bstJ2duDXmiKYH3KdsMgyPYXP77YkFo4X9FHeze2Ka7t11q/iNlV3Xu4fSqTrmEOn3VOm+XGSJkeXt9ieEEllWHxXW6ub3dGJsgVC95d1iFOhkwQl+K8tiRNfHzvyHZu3/WrSc0RdBk2aa2IGvGaEg6E2A9bT9KtX26jVYdyRQD76c396BrdeYUzekyOLpCcaVqqO/dJzRk8gRydQs2RGiLw+lRe72gJB0h8M4wTevN2aEtRHcVlcFxZwIYbZHK5lTl3PzxfU0e/NPExPBGCIC/GF145ujVBKIcDZ+O7UzcPvlAHXVpZ4/KmCA07xNn+4rf2cC6VVtaKvxU5auK5YQR3KMopqRI1266Qnq+92zggWdvd6bBCdeLSxbtUCifhu9f8nPCd1H+OFzjnho8HZIK6yZgJ+mTtcVHiyRf+/xnVjryZtC7IFTOCmoK7KbJfdpwWJbqcUf3+zkE0VpdJZRwo8doxLoczLIN1BP8t8hq0mLBAGuwBneEkFxojyJsJWndYVwqny/Zbc/0A7Wvi7zuzRLDpqC3HC8SsNc6sG97I4JtMt+myQdwoA+2yjSEI8mLSoFROocdFuP/dUVC/mRO6iLtvXH7w+l/ylMXxgmCp7t32IMj+F7+1uhe2ST0SZekuxnMceG0Q+9UFd+g4kyX9vOO7JyhaDicN+jQtA+LnZFLPRKd0ibtQDhfsEaVbnEDjxja8tstR3I78k/UnxMfPTerSpBJPT8Drbbibl1SWqVZ8cR0Z7K8vrf3lniE0IMU4OIkKDRBzaeQoiVusa8IwoUeCR80TlG6G8c1gLs+V6/VovW5tjqVSOENjusRRi/BAceOnKa2spRtphlkgCb/OcLMEPv+vOpjj8GN4Is85msFuUmehuIigBt1LAJxVyvH2tb30U7OlidpNcbKwQrS75nKQtroJ7I1JcmBW0FFdA4OeBu1Om+qyXtoLfmfPUGK8AJd/VG7qINWMH8kpc0onNmv4TqRUvsgdjCx1E1y+/yydr5ZniGFVbZ24yHCHu/y2CA/y15dubUvXti12xCtL0sTF37D2MfrA2JvxepfdL1yi+pIv7nDJa7e4Octv9w6xuBZS+p0ua0JJHP/tSF9/WU91Py/24uCDXze4GllaHy3H/DNuOMN/o/2Smze6Pa89u7qvtoSxKeVqUhDE3ehM8c0NqRsdGiQYQxDkxaS5GZ5wZxTcB9+dnD40RT81u6SJZXFSKVwnnvpu411KXgPHd9K5TtqWDmkcKEhd3NrrprzLoXOC9uIlv6yazlU4t1ObtPC2bWyYCBa5LS/Xkcu9KNiW/eDnnQcVmgta+7ZpLrpPlVfX0QqZ7lrmFGsDIL7g4XI7TyC1Sl53JNfh7lUr0nJEydRLl3XzmMXuTeUuzwOXUX01fQAlx1i+8cMZLf5x9mSec3hw6oYj+aIMmMcKmGabPGJWkFQVcE6edUFSxQDfWLC1uQbPiGJrDudRrm6Jgr3rHfn1ie9lD0k139nx5sHJ4mY3lzbywG/QQhDkxTypWxK4lyfHd6KUmFCxTuPVxdpF2U1uiqALKGwhZgXpSkBtKYnjIKX4fI24oDCc8i5HZozbpLLjJp3bnNUUIVUEQL7UThfMubokzrApgrkMNF+YXNGrlVE3vqY6o2+KEOI2F7mNkdYbcDBjbzaPsz+zFh0QH08bmkId4m1rKALuhcvc++uyEY42SFikG+jMHTHdechw4+tDz8vcGtv2EQrc8p6zRpwl/82BbqEbdeV3PVo3E2WQltY/8RgC9g2Gp+ohCPJi0qBUZILA1UID/ent63qJoIIX964+lNP0pgi6jlm2smddkJQF4jI6uddNtNOVNR138rwgqT12W92Ues6cKTE0dX+W5VI4yZW67ntcLslrF2WbEeRBWW++K8+tkrmxhr0NLr7+J10cD1wO9PDYDk7bR1DepboucY6sC+J1hCvTtOdmtZcIqqE5Areg/vdUkc1NEQxdr8sG/brjtN03NaRuqxc1Mt9r+tC24v2Cf7OoSKEZcWqDIMiLSenxBA+6MAD3uoi7Y5j2pPzSn2kOt0S2d0aQaRCUaUOHuGO6UjJpSKWcpIzMcRnmRFgjdYiSMllSEHTExR3iuGbedDilqfZxEdS9VaRo3CK1JW8KT8x6czA+JDXGqBuVLbjc5v2VR8XHT47vTJHBnlEeCGR1XdD2jEL9ujhbcXkWl6VyoNBHxrWQaiK9DmTJEATxuhxeX8Tr9exts84NYcIC/cR5enuGNpCyBQdMG48VNJgPZM6AlOaieVBlTT19uPqYy9eDqhGCIC+GQamgtBnjOoo1GrxoXxrGZw9eRyM1+Ohs44wgR9pkS1kapwRBca4NgqR1OJ10JVCuLIfjzklS+aLUjtgSaWaQHCVxnpgJMuw+JZXg2OKD1UfFhW2vpGZ0rW5BNnguPs/x3xpfnEtZHVst3qu9ATG5V6LHlJE6c1YQj1GwtSucudLoybrGE/O2294ggTP5HNyGBPhRnzbWA1X+HUpt8L/alE6zFqWJc7I3QxDkxTAoFdRQFsdrEtictcftvjOVpssC8UJ6e+9oO1IOJ2dTBEk7XWZGegxn4GBRagChD4J0mSAOvpoyn8IeGQXlohkDl3FJP7e1WSi8ZmjXqXO0O1M7BNBR2VImyAMGpRoa2SlOf5e/vKrWpvKmP/7VrvF48tJOHrnGAyxng+y50cSB8hrdRb2ndYUzmwlqYoMYfu3SrweysxROMmWAtiTur33ZNs/Rk9YDDUqNFmtdG8NljS9e1lXfKe6xX/e47PyvRgiCvBQGpYJaTBuSIu5icUCzQXdCd2ZTBEcWxEoBipS1kZMUWHE2jNvROrMpQkJksLjjyLhcg9u41tRpmjxM0d75QFy62FgnP560LrXLfn/lkSY9rpQtbOlB5XCMm4u0iQ4Vv8PNNgyXXXkwh0qrasXvXiqlA+9ZF/TP8XzR4MUWG08Ui7IpPsa4iYmnatUsVH9T2NGSbCkjk1uqzcg42kWvb5tm4uYQd89ctCe7yfOBLLltWFt67/reojMkrw+657udso0jcDcIgrwUp08xKBXUoHlYIN0wMEmfDbLHwWzdkFQHXqQNyyCsZaD4jpzURMQZ5XA87JAnvnNVwskCedq0WmqKYNjZjksjOsaHu7Q5wn5dZ7juVpoiGHpgdHuRDeK1CU3JBunL4TwsE8S/Q3tK4hbs0pYWXtG7JbJAXoTPW/zGwbKtAzlXHinUZw48tRROmpPI4wLEjeEmDB6W/v54BISjzXP4eb5elw2aZ8PMIL5ptjXdtvVApq7s04o+u7WfGBuw+lAu3frVVpsDZE+CIMjLS+EwKBXU4M6LUsVdqc0nCuy62HW0KYLhrCC+21lgpVOO1LqagxWeJi83fuGTmiM4qyQuPV83I8hkLk8nXQbtsIvmRuiDoFa2/b5SWoQ1ORvEdzjPVdR4XGMEiRQErT2SazWY5y570oXa1X21zyl4jwnS4FQbSuJKztfQlpPac4K0TsVTcUmovkNcYYUi64EM8eBUfi3k2U6NrdfcebJIvH7xa5O0xtMeF3eOp+/vHCRuwnEzhhs+20K5pfIMjXUXCIK8VPY5z1woDO6JX4Su0C2E/8TGbBDPOjmaq8sEORAEcf00l4c1VhLnzPVADTrEOSkIutAe2yQI0mWCDp91blMGxhfoF4Ig2zJBcmSDpBlB3HkpMlhbCuhJ+M4z38nOLDxPGVYyibzInbP/vEieu++Bd5bEcbBcUW19/djfaTkia8RdzqS1g55MPzDVwQ5xXC2wQ9fRralBUIvwIBrTJc6mBgmbDErhHM3WDUiJpnl3DxGPyzcVr/tkM2U2IRh0NwiCvL0pggfeGQX3dO/IVPF+edpZmzqlaRf0a8RdLKm0zRmdgfRBkBNK4STt4sKc2iFOWvMjBVsNMkE5zs8E8UV6SWUtBfr5Ugc7LsI5GyR1inMkG3ShKYLnDEo1xGu8pDUI63R3o81ZsFvbEAFZIO/E63r4fMeZA56/ZY3Uln5yz0TyBq1164IcbY7wx+4z4gYDlxvz+aqppJK4Bf+etrpOVGqKYM96IHO6toyk3/8zRDQY4pLsJ3/bS94CQZCXwqBUUBueWj+2SzxxRc9n607Y1RTB0YtbW5ojuCIIkrJM0jwiOXELVNP22BLpLi8HKNy1zRXzgfgxA/3te+l58GLHs0FSJsiTs94jGlkXdLKwkvaeLhbPoacOvQTr+Bw53obBqdxFcpNu7gzPrvEGFzJBFQ5luL/dnCE+vnlQsiz7M6JDLMVHBlFRRQ2tTMu12PFzry6zPqyJQRBLjgmjH+8cTNwwksvSXdUsR2kIgrwUBqWCGv1nlDYbNP/f0/o5Vo2tB3KkKUKDgalW0v9Sdsa5mSCpHK5c9rkNHARU1daLkinTjFl0WKCoJ2dHnTw0dZ8DpXByZIOkTJCndYYzJJXg8MULt8E2tfRQgX47LnsB726VvepgrignNocDJM5qdIwNoVQZshqe3iZ7y4lCOpJTRqGBfnRNP3nmbnHnzGt138tSgwTuBsk3DLlkUa6B90nRofpzyS82NGbwBAiCvJR0gdnSzqnGAM7ULzmaBqZEizK3LzdazwYd1C3m72LnkFR7ZgVxKcLJgnKnB0Hc5pgXw3JrVClLKxfpjp54DDNtqTsnuGZoqr1NEaxlg3jRsLd3hjP9HXKTGy514plBhjioXnZQ+zmpyQR4p75tmoubHtwmffbSg2Ixf55JR7TFe7Vlk2M7Otbm2R3ZMy7B1Df/ZOj/tuRsnDOlv7YkjksXu7+4nLo8v4w6PreU2j/zF7WduYT+88Muh7rC2VqK99vO001qGe4uEAR5+Zogue4gAMhFmmj949ZTVKzr6mXqRF4Z7c/SZYIS7c8sNHzxM58JysivEK2rI4L8xUWmswT4+epryeXuEHehPbb5IE7qKuTMNtlcMnJAV75oa3tsq9mgVUfJ22cEWWqVbbreY8fJIjpbWi1mQl3SNV6hPQS1dEKbqMsGzd2UQdPnbqcBr62kQa+vpNu/3k5vLjtEW05os4ZjOzYnbyGVw3GFjD2ZeM4c/Z2mLS28dYh26LdcuDyNy8MZlyrzDTLO3nGWTmoCyWXFUkMhuVzcOZ5ahAeK4JhvOHk6z2uVA3YNSvXkCwNwT6M6xYo723xR/t2WDHrg4g76/zuWW0ofrj5Gi/acEcEJn6w76DqcNTUTxBfqpmuLDIekOntRPQ/J48fj8jtpjYecmSBLpS0ddZmgI42Uw3FAOm/HKZrQPVGUTdiDAxFea8DZrqZ0m+Js0MLdWWKuBWeDeiU1s70TpgdngqQp9b/uPC3WBT076cLneRii1CLZ0fkl4DlmjOskbv7wepIDZ4rF+SGnpIpySnLF3xXrnRRFLaO8p2wyPiJInJu4AoEHntp6c/jHrSfF69Dg1GindNH79JZ+Yog2v/JwFpyDWD8ffk/iPTdFkftvOtDfV7Tp/mz9CdGdztNvnCAI8vJBqdJ6AAC14GDj3pHt6JF5u8XdSp4hxGt2Plh9TJRqSHfBxnaJoycu7dykFwHujsixDa+ZyS+rbvD34IqmCBJt57Yc2TvESd/PtCmCveVwzyzYJ7pGfbT6GH0wtQ+N6qRt42pPKRw3v2jK74uzQTzoc/6uLJEN+mr6gEa/xls6YXKHKF7UzOsT+I42lzrz+qC/dIvgr+qDhghAomTrrhHatZesvKpWrK/kTC0HRdwk5f7RnI233JXM03CZMAc+fDOMqwJsCYL4b+unbdp1M9OHypsFkvA1mqXztjNN6Z8kgqA1h3Mpt6SS4nSjJDwRyuG8kHRRwHc/+I8MQG24NStnaXiI6TVz/qFx760X2R8OgMZ1jafFDw6nL6YNaPLdN77rdWFWUMOSOKlbm+uCIPnL4fSZIAvlcNyumgNBfq75Bok5nIH7a7+2bS63ub7t6+308ZpjVodzGjqgC4J6OLgeyNCDF3cQF/tSNsiaksoafde7lh6eCWoWGki9dZkxqSSOF8CXVtZSQkSgWGsHYIqzCf1Tomna0BR669pe9NPdg2louxive6LsbY7w175skd3mrpNS2ZqnaB8XTv2Tm4uqod92nSZPhiDIC0nlIVgPBGq+M3fXRdq7lXyHkq+1ub3rkoeG02e39neow5gjzRFcMShVIgVax3VreOTAdyulF3VLdxRDAv0oWVfeZikbxNkf/h2M6RxHNw5qIz5+e/lhuvf7nTa11m5KZzhT/HNc2ce2tUFSZzi++x0a6PmFDyM7xhm1yuY5I+zSztGilAYA5GmO8M3mk+L9zYOTzTaccXdTdA0SftmeafPNLnfkeb85sL08BJ3hQMW4Sw3PqeDyp6UPX0Sf3NKPujm4qN6aJAsvfnwXjBswuCoTxIP2GC9ILT5vviGEvXjwHb9+8UBZXj9liZRRM9ccgTNJf+7Rdox6ZGxHev2qHvTG1T3E0NPlB3Loyo83NVrCt1/XFEGu359hNkj6HXnrjCDTdUHSEEUuY1mrW9g8vguyQADWtNJdD9kSBPGsMs5C8zlQ6qbmaSb1SKSwQD/KKKigrenGHSc9CYIgL6RvGevBdZ7g/njtyMc39qX3b+hDXRKbXkbVeCbIuBwuq0g7X4dL5uxtBOCIiOAAMSCPybUuKD2/TN8UwVpjB6lD3BEzQdD/1hwTi39Hd4qlHq21QcwNA9vQvHsGi1JCzpZd+dEmWpGWI+4Y8hoDfi55HdCmY/n0645MEdhx0NJVpt8jZ4OkAYHLDpxtfEaQl9zw6dEqipqHBogWyC8vThNrP7kledto7/j5AeR+HTBHGo7KZdueOncrLMifLu/dUp8N8lSeXx8ADSATBNCwDCLT5A7gsbxSfQDhqrVznHHiTk3Hc8vETI+mkkrrLK0HknRK0AYnh0w6xHFDivm67mIPjrnQpY/1adOcFj04nO7/YRdtyyiku77dIe6MVluYLcFrj7j0Ti6XdkugDUfzRTbqvlHtrd/w8ZJMEB+nF3WIFZm7xXu1a7iukrmFLoAnt8nmm1/W8LrJxXu0f1u3OqkhglpM6Z8kmj/wetAXL+8m6xwktUAmyEPxHVlLdZzSoFRvuTAAcOQOoGF7bFeRmiPItS5IaorQWIchqRzuaE6p0ZyM/609LsoCufOYuaCMu+n9cNcgfXckKQDiYIjnKnGGaWDbaLq0Wzy9cFlXkhM3yODkFpelSOc0U2e8LBPEpHlBUlB0Wa9ERfcHwB1IZdG8htLaGhhuG83nuV6to/SNSDxV76Rm4hzOQ5ilkmhPg0yQB+KLlus/3Uz/Zp6jkAA/UVYUGugnPuY7sYfOauvz0RgB4EImKMtkVpArmyI4q0OctF5GWm9kSUpMqCj7q6iuEzXxbWJCRZvl33Zm6ufzWBv0+tLl3ei+Ue1E+VWz0ABxrnH2XCVu28qB2c6TRWJgoblhhd6WCWIXdbwwQX5EhxaiXCe38QofAK/G10Oc8OcS6LyyKoqLaHjOqK2rp++3nHTKcFQ18vHxEQ0SXlmcJkribhmcTJ4GmSAPxBcvPCWcgyHu3MTpWx64dTinVCzo46ieL3jaxri+/zyA2l/8lJgRJJEey9pif2dkgri7kRTsSTdJPl13XAwP5EzOoNQYm4ISzrhwFzZnB0ASzjCx5RbWBXnLjCBDfPEmDZG9tp9nLtoGkBvfzJHGJVgqiVt5MEecU6LDAkXTHm9wVZ9WFODnIzp88hwpT4NMkAeSLuT47udPdw2m8zV14g5vpe49/5vXOTQPs9wtCsBbSLOCzhRXiiwIX0RyRkiJIEjKBJ0srKBqXVMGRxWVV1NRhbbLnC0D93hoalp2iWiTzWUQP+kWwz5sshZITXhd0Ot/HaItJwrpXEW1mJUj4d8h3xDyhhlBpj68oQ/tP1NME7oneHR7WwC5qwKk1wFe82jqm3+0WaAbBiQ1aeizO4kOC6RxPJ5ib7bIBs26Qv4OrUpCEOSB8kur9HdmecI6ANj+4sclVnwjgYeCcobIlRO7uTsctyUtr66jkwXl1EHXtc0RJ3RZIL4ZYsuMnI66dUGcMeZp4RyE9W3TTNWDE5NjwkTwxq29eTDoNf1a6/+PA0DO7nlj6S+XM/IbQxAEYEdzhAztuiC+icQ3hdLOlIgMCH98JKdMvCbc5IFlYdZc3z9JBEELd5+hmRO7eFQAiCDIgzNBsR7auhHAGc0RtmVcaI4gZYG4NbYrT/hcRsaNGPaeLhZtspsSBNlaCmfaHGHXySJ9Bok7wrmqtM1RfJeSgyAuiTMMgqQsEM9HCvL3nBdtAHBuk5x3/z5Cbyw9ZHYbHg8gzRTyFsPbtxA/MweHfJ69woM6TiII8kD5pdXifWwEyt0A7OsQp71w5hbVrm6KIOHH1AZB5S5piiDhjArjjBjr2TqKRhl0GlMrXhf0waqjtP5oHp2vrtO34fbG9UAA4DhpjpnU5ZIbxnRtGSk+z+95Xp03nk98fX3ouv6t6b2VR+mXHZkIgkDduBEC89QhXgBya60bhioFQUqsB5JILbmb2iHuQibItp+B10VFBPtTaWWt+PcDo9urPgvE+AKFg1j+3a07kkfjuyd4bWc4AGjaGsOvbxsgBoXyTSEeYA1a1/bTBkH/HC+gnJJKitc1kfCKTNDevXvt/sZdu3Ylf38kmpTA09mlGR4AYEcmqFBXDpfn+hlBkna6zA2XwzXFCf2gVNsyQRzw8Av/9owi8f6SrtrOa2rH+80XL19uTBelGlIQ5I0zggCgaRmPUZ3i8BRaWDfbP7m56Dy8aM8ZuvOiVPIENkUpvXv3Fi80ti6w9PX1pSNHjlBqqmc8Se4GmSAAxwblnT53XgwLVTITJD0ml+QZzi2yB/8M6QW6IMiOxg6TeiSKVqjPTOziFlkgiRQErTqYQzV19aLdLTJBAADyubx3S+8MgtjWrVspNrbx+nB+0e7evXtT9wuaAEEQgGOzgrgjGndVyympUiwIahMdRn6+PqJD3NmSSodq0HkBK/8sPN9BGgZri+nD2oohgHxH1J30S24uGiDkl1XTlhMFdFGHWMrWZYISkQkCAGiyiT0SadaiNNpzupgy8ss9ovuwTUHQyJEjqX379tSsmXYAW2NGjBhBISEoQVAKyuEA7MOZAw42OHjgdSUsLiKIIhWoCefZQMnRoSIYO55b7lAQJK0H4hbSHFDZw90CIMY/I5fv/bQtU5TEcRB0RrcmqCXWBAEANFmL8CAxMmHD0Xz6c88ZekjFM+RsZdMkvjVr1tgcALG//vqLEhNtm6ablZVFN998M8XExFBoaKgovdu5c6fNjwXGuDsS30FmfGcUAOyYEUFEaw/nKpYFkkhrkRxdF2Rve2xPwK2y2d8Hcqi2rl4s3mXIBAEAyOMKXXtsDoI8YQaZ4+PIZVBUVETDhg2jgIAAWrp0KaWlpdE777xjV8AF5kvhgvx9KTwIjSkA7G2OsDW9UPkgKLbxDnGZhRW0+XiBeM8X/U1pj+0J+A4ln/NyS6to1aFcqqnTiBLHeDSIAQCQbSRBoL+veG06mF3q9s+q3VfJHPn99ttvIjuUm5tL9fXGL77z58+3+Xu9+eablJSURHPnztV/LiUlxd5dAgN8ASClLd1pYTOA0qS1M7yWRvkgyHqHuD2Z5+jmL7fps75cDsatoDmQ4yYP2zMK7W6K4O54IOroznFi0e7XmzLE5+IigsnfT9F7fQAAHiMiOIAu7hRHyw6cFdkgnp/kVUHQww8/TJ999hmNHj2a4uPjm3Sh/eeff9Kll15K1113Ha1bt45atWpF9913H911111mt6+qqhJvkpKSEvGeAzHTYMzV+PE5QFR6P/JKK/WDUpXeF3CPYwa0WjUznnvAAYRSv5vUFqH6IMhwH/jjE/kVdN/ve0UA1Dw0QLznwI3n5PDbFipUxc+ghHFdtEHQ5hMF4t8cGHrTz28OzjOAYwbkNLlngi4IyqLHL+kg1pGq6Txjzz7YHQR9//33ItszceJEaqoTJ07QnDlzaMaMGfTMM8/Qtm3b6KGHHqKgoCC69dZbG2w/e/ZsmjVrVoPP5+XlUWWl9uJfySe9uLhYHATcIlwp6WfyxfuIABKZOlAvtRwzoBVOF26wsGa+lYr9DUWSdmApd6lLz8ymsCA/8W9u3PDg/CN07nwddY0PpY+u6UjBAb5UUF5DZ0qqKbukis4Ua99HhwZQq+BqrzoPdI0mCvTzoeo6ba16dLCPV/385uA8AzhmQE7dY3woNNBXzGJbtTederUMV9V5prS01HlBUFRUlGzzf/hJ69+/P73++uvi33369KEDBw6IwMhcEDRz5kwRMBlmgricjlt3R0Yqm5Ljn4WzYrwvSh4AVT7F4n2rmEiKi8PQLzVTyzEDWj0CuPztiPg4ItifuqS0VKyklP9yYyMOiU6PJRRCbeOaiY9nfHeQCirqqH1cGH1312BqHqptfsItAbrhFykMa59Faw5rO/ylxEd5/XkQ5xmwF44ZaMz4brk0/98s2njqPF3SO1VVx0xwsHFVh6xB0EsvvSSyMV999VWT22BzB7muXbsafa5Lly70+++/m92eM0T8ZoqfcKWfdMYHgNL7kl9erW/vq4bnBNR/zIBWy2ahYm1NXb1GrAfy89NmX5RcF8SBD5e/pcZF0PSvd9DJggpKjAykb28bSDHhtp/ovcn47gn6IIh/p/jbwnkG7IfXJmhscCoHQX/tO0svXtZNnGfVcszY8/h2B0G8fuenn34Sd9e4iQF3djO0a9cum78Xd4Y7fPiw0eeOHDlCycnJ9u4W6OSXaoOgFuiIBGAXXkCfEBksSs7a67qzKYkDsS0nCmn/mWL6efspOphdItref3B1BzHcFcwb2yWefH32Ub0GM4IAAJxhWPsWFB0WSAXl1bTpeAFd1D7GLZ9ou4Og6dOnizk+PNunqY0RHn30URo6dKgoh5syZYpYE8RNF/gNmtYim7vDAYB9uLuaCIIU7Axn2ib7638yiMcxcIneN7cNoBg/Zdc/ql1MeJCYZbEyLYf6JjdXencAADxywPikHon03ZaT9OfuM94TBC1ZsoSWL19Ow4cPb/KDDxgwgBYsWCDW+rz88svUtm1beu+99+imm25q8vf2Vnm6ICgWmSAAu904qA1VVNfRhO62DXt2RRDEARA3P/hq+gDqkhhJubkIghrzf9f1Eu+5vBEAAJxTEvfdlpO0/MBZeuUK46UtHhsEcSMCOZsQTJ48WbyBPPIN5gQBgH04gyBNxFZa58QIcRHPl/Fzbu5HA1KiVdF+1B0g+AEAcK5+bZpTy6hgOlNcKdZh9otzv7XNdu/xO++8Q08++SRlZGiH0YF6VFTX6ocn8toBAHBfPOjzuzsG0vz7htLoTuj0CAAA6uHr60OX9WopPub5bF6RCeK1QBUVFdSuXTsKDQ1t0BihsPDCoD5QpilCkL8vhQfZ/asFAJUZ2q6F0rsAAABgsSTu0/UnaPXhPHpihPJl5Pay+0qZ1+yA+tcDKTXfBAAAAAA8X9fESDHO4XheOa09fo7aJiV6dhA0bdo05+wJNBk6wwEAAACAK/j4+NDlvVrRf1ceoRWHC+m2Ue71vDtUM8WLc48dO0a5ubkNFuqOGDFCrn0DOyEIAgAAAABXlsT9d+UR2n6qRFyHxkWGeG4QtGXLFrrxxhvp5MmTpOHerSYRYV2ddmE+uB5Pl2dojw0AAAAAzta2RRjdN6odtYvyoagQ4z4BHhcE3XvvvdS/f38xLygxMRFrT1SYCYpFZzgAAAAAcIHHx3UU1WE8RNWjg6CjR4/Sb7/9Ru3bt3fOHkGTu8O1wKBUAAAAAACL7A7ZBg0aJNYDgYq7w2FQKgAAAACAfJmgBx98kB577DE6e/Ys9ejRo8GcoJ49e9r7LUHuxgjIBAEAAAAAyBcEXXPNNeL97bffbtQQgZskoDGCsvJ1jRFaIBMEAAAAACBfEJSenm7vl4ALVFTXUnm1tjMfusMBAAAAAMgYBCUnJ9v7JeDCpgjBAb4UFuiH5xwAAAAAoCmNEf7880+qqakhW/311190/vx5m7cH+ZoicCkclyUCAAAAAEATgqCrrrqKzp07R7a64YYbKDs72+btQcamCFgPBAAAAADQ9HI4bnowffp0CgoKsmVzqqystGk7kE+erikC1gMBAAAAAMgQBE2bNo3scdNNN1FkZKRdXwNNg0wQAAAAAICMQdDcuXNt/HagdBAUGx6IXwIAAAAAQFPXBIH6oRwOAAAAAMA2CII8RH6ZtkU2GiMAAAAAAFiHIMjT1gRF2Na8AgAAAADAWyEI8rRyOLTIBgAAAACwCkGQB6iorqWK6jrxMTJBAAAAAAAyBUFbt26lpUuXGn3u22+/pbZt21JcXBzdfffdVFWlzUaAa+WXatcDBQf4UligH55+AAAAAAA5gqCXXnqJ9u7dq//3vn376I477qCxY8fS008/TYsWLaLZs2fb+u1ARnlllfqmCD4+PnhuAQAAAADkCIJ2795NY8aM0f/7559/pkGDBtHnn39OM2bMoA8++IB++eUXW78dyChPlwmKRVMEAAAAAAD5gqCioiKKj4/X/3vdunU0fvx4/b8HDBhAmZmZtn47cEZnODRFAAAAAACQLwjiACg9PV18XF1dTbt27aIhQ4bo/7+0tJQCAgJs/XYgIwRBAAAAAABOCII468NrfzZs2EAzZ86k0NBQuuiii/T/z+uF2rVrZ8dDg+ztsVEOBwAAAADQKH+y0auvvkpXX301jRw5ksLDw+mbb76hwMBA/f9/9dVXNG7cOFu/HTghExQbfuH3AQAAAAAATQyCYmNjRRaouLhYBEF+fsatmH/99VfxeXC9/DJtYwSsCQIAAAAAkDEIkkRFRZn9fHR0tL3fCmSCcjgAAAAAACcEQbfffrtN23FZHLgWGiMAAAAAADghCPr6668pOTmZ+vTpQxqNxo6HAGcqr6qliuo68XELNEYAAAAAAJAvCLr33nvFgNQTJ06IrNDNN9+MEjgVZYFCAvwoLNB4nRYAAAAAADShRfb//vc/ys7OpqeeeooWLVpESUlJNGXKFFq+fDkyQ2oohYsIJB8fHyV3BQAAAADAs4IgFhQURFOnTqUVK1ZQWloadevWje677z5RJldWVua8vQSL8krRGQ4AAAAAwGlBkCHOOvAbrw+qr6939NtAIzYfL6ACXbbHHDRFAAAAAABwYhBUVVVFP/30E11yySXUqVMn2rdvH3300Ud06tQpzAhygq0nCmjq51vo3u93WtwG7bEBAAAAAJzUGIHL3rgxQps2bei2224TH8fExNj5cGCPfzPPiffbM4ro8NlS6pQQ0WAbZIIAAAAAAJwUBH3yySciAGrbti2tW7dOvJkzf/58O3cBLDmee2Gd1a87Mum5yV0tBkGx4YF4IgEAAAAA5CyHu/XWW2n06NHUrFkzioqKsvhmj5deekm/tkh6S0hIsOt7eLLjeReCoAX/ZlF1bcO1VyiHAwAAAABw4rBUZ+AOcytXrtT/288Ps24YN5w4pssEBfr5UkF5Na0+lEvjuxsHifll6A4HAAAAAOCS7nDm/Pbbb3Z/jb+/v8j+SG+xsbFy7pLb4uCmpLKWePTPTYPbiM/9siPT8pyg8CCX7yMAAAAAgEdnglhtbS0dPnyYAgICqGPHjvrP//HHH/TCCy/QoUOH6Nprr7VrB44ePUotW7YUM4gGDRpEr7/+OqWmplrsTsdvkpKSEvGeW3Qr3aabH1/OduHHcrQ/W1LzELppYBLN3ZRBaw/nUva5CoqPDBb/V15VSxXVdeLjmLAAxZ8DUPaYAc+HYwZwzADOM6A29Sq6nrFnH2wOgng46uTJk+nkyZPi31dccQXNmTOHpkyZQnv27KE777yTFi9ebNeOctDz7bffioAqJyeHXn31VRo6dCgdOHDAbOe52bNn06xZsxp8Pi8vjyorK0npJ724uFgcBL6+TU+w7T6RJ963jgygcE0F9WwZRnvPlNN3G47QrQO0JXGnz2kDwmB/XyovLqTyJj8quPMxA54PxwzgmAGcZ0Bt6lV0PVNaWip/EPT000+LznAffPAB/fDDDzRv3jzav38/3XzzzSL4iYho2L65MRMmTNB/3KNHDxoyZAi1a9eOvvnmG5oxY0aD7WfOnGn0ec4EJSUliRK6yMhIUvoA4MYOvC9yHAC5VQXifZfW0RQXF0c3Dq6ivfP301+HiuixiT3EY2WeLxLbxEYEiW3Avch9zIDnwzEDOGYA5xlQm3oVXc8EB2urpWQNgrZt20Z//fUX9e3bl4YPHy6CoCeeeILuuusukktYWJgIhrhEzhwumeM3U/yEK/2kMz4A5NqXE3navE77uAjx/Sb3akUvLz5IGQUVtCuzmAakRItmCaxFRJAqfn5Q9pgB74BjBnDMAM4zoDY+Krmesefxbd4yNzeXWrVqJT7mNtmhoaE0cuRIkhOv9zl48CAlJiaSt5M6w7WLDRfvw4P8aXJP7fPyy3Ztg4Q8XWe4WDRFAAAAAACQPwiSIjz9F/r6igYJTfH444+Loavp6em0detW0VSBS9ymTZtG3ux8dR1lnTsvPm4fpw2C2JT+SeL9kn3ZVFZVS/mlus5wEegMBwAAAAAgezkcL3biBgYcDLGysjLq06dPg7RTYWGhzQ9++vRpmjp1KuXn54s6wsGDB9OWLVsoOTmZvNmJfG0WqHloAEWHBeo/3y+5OaW2CKMT+eX0195stMcGAAAAAHBmEDR37lyS288//yz79/QEx3XrgaRSOAkHoNf1T6I3lx0SM4OkAIkbIwAAAAAAgMxBkLeXqLnScZP1QIau6duK/u/vw7TjZBHF6YKf2PAL2SIAAAAAALAOLalU6FieLgiKC2vwf3GRwTSqY6z4OFdaE4TGCAAAAAAANkMQ5GaZIDZlgLZBggTlcAAAAAAAtkMQpDJ19RpKz5dmBJkPgi7uHEctDErgkAkCAAAAALAdgiCVOXPuPFXV1lOgny+1bh5qdpsAP1+6qo92ZlNIgB+FBdm8tAsAAAAAwOs5HARVV1fT4cOHqba21uufRGesB2rbIoz8fLXtyM25YWAbEQD1SorC8w8AAAAA4MwgqKKigu644w4KDQ2lbt260alTp8TnH3roIXrjjTfs/XZgaT2QmaYIhni90OrHR9Lnt/bHcwgAAAAA4MwgaObMmbRnzx5au3YtBQcH6z8/duxYmjdvnr3fDkwcz7PeFMFQYlQIRQQH4DkEAAAAALCD3YtJFi5cKIKdwYMHi+Gdkq5du9Lx48ft/XZg4niu+UGpAAAAAACgUCYoLy+P4uLiGny+vLzcKCiCpmWCLHWGAwAAAAAAFwdBAwYMoCVLluj/LQU+n3/+OQ0ZMqSJu+PdisqrqaC8Wt8YAQAAAAAAVFAON3v2bBo/fjylpaWJznDvv/8+HThwgDZv3kzr1q1zwi56jxP52ixQy6hgtL0GAAAAAFBLJmjo0KG0adMm0SWuXbt29Pfff1N8fLwIgvr16+ecvfS29UAohQMAAAAAcBqHpmz26NGDvvnmG/n3xstJM4LQFAEAAAAAQOEgqKSkxOZvGBkZ2ZT98Wr6GUGxWA8EAAAAAKBoENSsWbNGO79pNBqxTV1dnVz75nXsmREEAAAAAABODILWrFnj4LcHW1XV1tGpwgrxMdpjAwAAAAAoHASNHDnSibsA7GRBBdVriCKC/Ck2IghPCgAAAACAmhojFBUV0ZdffkkHDx4UJXBdunSh2267jaKjo+XfQy9xTLceKDUuHENnAQAAAADU1CKbZwGlpKTQBx98IIKhwsJC8XHbtm0xJ6gJ0BQBAAAAAEClmaD777+frr/+epozZw75+fmJz3EzhPvuu0/83/79+52xnx4PTREAAAAAAFSaCTp+/Dg99thj+gCI8cczZswQ/weOOZ6nG5SKznAAAAAAAOoKgvr27SvWApniz/Xu3Vuu/fIq3F5cygShMxwAAAAAgArK4fbu3av/+KGHHqKHH36Yjh07RoMHDxaf27JlC3388cf0xhtvOG9PPdjZkkqqqK4jf18fSo4JVXp3AAAAAAA8mk1BEGd4uAscZywkTz75ZIPtbrzxRrFeCBzrDNcmJpQC/OxOzgEAAAAAgNxBUHp6uj3fExzuDBeO5w4AAAAAQA1BUHJysrP3w6uhKQIAAAAAgMqHpWZlZdGmTZsoNzeX6uvrjf6P1wyBo+2xw/DUAQAAAACoLQiaO3cu3XvvvRQYGEgxMTFirZCEP0YQZD90hgMAAAAAUHEQ9MILL4i3mTNnkq8vFvE3VWllDeWUVImPU7EmCAAAAADA6eyOYioqKuiGG25AACTzeqDYiCCKCgmQ69sCAAAAAIBcQdAdd9xBv/76q71fBo12hsN6IAAAAAAAVZbDzZ49myZPnkzLli2jHj16UECAcfbi3XfflXP/PF7WufPifZtoDEkFAAAAAFBlEPT666/T8uXLqVOnTuLfpo0RwD65pZXifXxkMJ46AAAAAAA1BkGc6fnqq69o+vTpztkjLyM1RYhDEAQAAAAAoM41QUFBQTRs2DDn7I0Xyi3VBUERQUrvCgAAAACAV7A7CHr44Yfpww8/dM7eeKHcEpTDAQAAAACouhxu27ZttHr1alq8eDF169atQWOE+fPny7l/Hq2+XkN5yAQBAAAAAKg7CGrWrBldffXVztkbL1NYUU219Rr9nCAAAAAAAFBhEDR37lzn7IkXytU1RYgJC6QAP7srEwEAAAAAwAEOXXnX1tbSypUr6dNPP6XS0lLxuTNnzlBZmXbwJ9gmR9ceG53hAAAAAABUnAk6efIkjR8/nk6dOkVVVVV0ySWXUEREBL311ltUWVlJn3zyiXP21APlSe2xUQoHAAAAAKDu7nD9+/enoqIiCgkJ0X/+qquuolWrVjm8I7NnzxbDVh955BHyFjn6znBYDwQAAAAAoNpM0MaNG2nTpk0UGBho9Pnk5GTKyspyaCe2b99On332GfXs2ZO8c0ZQsNK7AgAAAADgNezOBNXX11NdXV2Dz58+fVqUxdmL1xHddNNN9Pnnn1Pz5s3JmyATBAAAAADgBpkgXgP03nvvicwN4xI2DmRefPFFmjhxot07cP/999OkSZNo7Nix9Oqrr1rdltcg8ZukpKREH5jxm5L48TUajV37katrjNAiPFDx/Qf3OGbAu+GYARwzgPMMqE29iq5n7NkHu4Og//73vzR69Gjq2rWraIRw44030tGjR6lFixb0008/2fW9fv75Z9q1a5coh7N13dCsWbMafD4vL0/si9JPenFxsTgIfH1tS7Bln6sQ7wNqKyg3N9fJewhq48gxA94NxwzgmAGcZ0Bt6lV0PSN1rXZKENSyZUvavXu3CGB27twpfvA77rhDlLQZNkpoTGZmpmiy8Pfff1NwsG1rYmbOnEkzZswwygQlJSVRbGwsRUZGkpL4eeCsGO+LLQdAfb2GCitqxcedkhMprpntzx14BnuPGQAcM4DzDDgbzjPgzseMrTGFQ0EQ42DntttuE2+O4gCKsx/9+vXTf47XGq1fv54++ugjUfbm5+dn9DVBQUHizRQ/4Uo/6YwPAFv3paiiimrqNOLj+MgQVew/qPuYAcAxAzjPgCvgtQnc9Zix5/Ht3tNvvvmGlixZov/3k08+Sc2aNaOhQ4eKGUK2GjNmDO3bt09klaQ3br3NGSX+2DQA8tTOcNFhgRTojwtgAAAAAABXsfvq+/XXX9eXvW3evFlkbXhQKq8JevTRR23+PtxJrnv37kZvYWFhFBMTIz72ls5wGJQKAAAAAOBadpfD8Vqe9u3bi48XLlxI1157Ld199900bNgwGjVqlDP20bNnBEViRhAAAAAAgKqDoPDwcCooKKA2bdqIpgZS9ocXIp0/f75JO7N27VryFrnIBAEAAAAAuM+coDvvvJP69OlDR44cETN+2IEDByglJcUZ++jRmaD4yIaNHgAAAAAAQEVrgj7++GMaMmSImM3z+++/izU8Ure3qVOnOmMfPXxNEMrhAAAAAABUnQniTnDcDMGUuSGmYBkyQQAAAAAAynBoTtC5c+do27ZtYs4PD0gy7BF+yy23yLl/Hiu3RFsOF4tMEAAAAACAuoOgRYsWiVk+5eXlos01Bz4SBEG20Wg0lFuqLYfDmiAAAAAAAJWvCXrsscfo9ttvp9LSUpERKioq0r8VFhY6Zy89TFFFDdXUacTHsRFojAAAAAAAoOogKCsrix566CEKDQ11zh55ASkL1Dw0gIL8/ZTeHQAAAAAAr2J3EHTppZfSjh07nLM3XiJHtx4IneEAAAAAANxgTRDPBXriiScoLS2NevToQQEBAUb/f/nll8u5f549KBUzggAAAAAA1B8E3XXXXeL9yy+/3OD/uDFCXV2dPHvmBe2xkQkCAAAAAHCDIMiwJTY0LROEznAAAAAAAG6wJgjkXBOEznAAAAAAAKoNgiZOnEjFxcX6f7/22muiRbakoKCAunbtKv8eeqALM4KCld4VAAAAAACvY3MQtHz5cqqq0mYw2Jtvvmk0F6i2tpYOHz4s/x568pogNEYAAAAAAFBvEKTRaKz+G2x/HnPRIhsAAAAAQDFYE+RixedrqLpO21wiFmuCAAAAAADUGwRx+2t+M/0cONYUoVloAAUH+OHpAwAAAABQa4tsLuOaPn06BQVpO5pVVlbSvffeS2FhYeLfhuuFoPGmCOgMBwAAAACg8iBo2rRpRv+++eabG2xz6623yrNXXpAJQmc4AAAAAACVB0Fz58517p54WSYI64EAAAAAAJSBxgguJnWGQyYIAAAAAEAZCIJcDGuCAAAAAACUhSDIxbAmCAAAAABAWQiCXAyZIAAAAAAAZSEIciFuM45MEAAAAACAshAEuVDJ+Vqqrq0XH6M7HAAAAACAMhAEuVCOrj12VEgABQf4ufKhAQAAAABAB0GQAu2x4yKCXPmwAAAAAABgAEGQC+WUaDNBmBEEAAAAAKAcBEEulFuKTBAAAAAAgNIQBCmQCYqLDHblwwIAAAAAgAEEQS6Uh0wQAAAAAIDiEAS5ENYEAQAAAAAoD0GQEmuCItEdDgAAAABAKQiCXESj0VzIBEVgTRAAAAAAgFIQBLlISWUtVdXWi4+RCQIAAAAAUA6CIBfJ1WWBIoP9KTjAz1UPCwAAAAAAJhAEuXw9EErhAAAAAACUhCDI5Z3h0BQBAAAAAEBJCIJcnQlCUwQAAAAAAEUhCHJxJghNEQAAAAAAvDgImjNnDvXs2ZMiIyPF25AhQ2jp0qXkiZAJAgAAAABQB0WDoNatW9Mbb7xBO3bsEG8XX3wxXXHFFXTgwAHy1O5wWBMEAAAAAKAsfyUf/LLLLjP692uvvSayQ1u2bKFu3bqRJ0EmCAAAAABAHRQNggzV1dXRr7/+SuXl5aIszpyqqirxJikpKRHv6+vrxZuS+PE1Go3Z/eDPS2uCYsMDFN9XUAdrxwwAjhnAeQaUgNcmcOdjxp59UDwI2rdvnwh6KisrKTw8nBYsWEBdu3Y1u+3s2bNp1qxZDT6fl5cnvl7pJ724uFgcBL6+xlWGZVV1VFmj/aX4VJZSbm65QnsJamLtmAHAMQM4z4AS8NoE7nzMlJaWuk8Q1KlTJ9q9ezedO3eOfv/9d5o2bRqtW7fObCA0c+ZMmjFjhlEmKCkpiWJjY0VjBaUPAB8fH7EvpgdASW6ZeB8R7E9tWiUotIegNtaOGQAcM4DzDCgBr03gzsdMcHCw+wRBgYGB1L59e/Fx//79afv27fT+++/Tp59+2mDboKAg8WaKn3Cln3TGB4C5fckvqxbv4yKCVLGfoB6WjhkAHDOA8wwoBa9N4K7HjD2Pr7orL06lGa778QQ5pVJnONujUwAAAAAAcA5FM0HPPPMMTZgwQZS0cQ3fzz//TGvXrqVly5aRJ8ktqdJnggAAAAAAwIuDoJycHLrlllsoOzuboqKixOBUDoAuueQS8iR5pdogKBZBEAAAAACAdwdBX375JXmDc+drxPtmoYFK7woAAAAAgNdT3ZogT1SsC4KiQgKU3hUAAAAAAK+HIMgFEAQBAAAAAKgHgiAXKEEmCAAAAABANRAEuQAyQQAAAAAA6oEgyAUQBAEAAAAAqAeCICerqauniuo68TEaIwAAAAAAKA9BkIuyQCwS3eEAAAAAABSHIMhFQVBEkD/5+fo4++EAAAAAAKARCIJcFAQhCwQAAAAAoA4IgpwMTREAAAAAANQFQZCTYUYQAAAAAIC6IAhyMmSCAAAAAADUBUGQkxVXaNcEoT02AAAAAIA6IAhyVSYoNMDZDwUAAAAAADZAEORkKIcDAAAAAFAXBEFOhhbZAAAAAADqgiDIyUoqsSYIAAAAAEBNEAQ5WfH5WvEejREAAAAAANQBQZCTYU4QAAAAAIC6IAhyMjRGAAAAAABQFwRBTlRbV09lVSiHAwAAAABQEwRBTlRSqQ2AWGSwvzMfCgAAAAAAbIQgyAWlcOFB/uTvh6caAAAAAEANcGXuRFgPBAAAAACgPgiCnAiDUgEAAAAA1AdBkEsyQVgPBAAAAACgFgiCXJEJCg5w5sMAAAAAAIAdEAQ5EQalAgAAAACoD4IgJ0JjBAAAAAAA9UEQ5ETFFdKaIJTDAQAAAACoBYIgV2SCQhEEAQAAAACoBYIgJ0I5HAAAAACA+iAIciLMCQIAAAAAUB8EQU6ETBAAAAAAgPogCHIitMgGAAAAAFAfBEFOUlevodKqWvExusMBAAAAAKgHgiAnZ4EYgiAAAAAAAPVAEOTk9UChgX4U4IenGQAAAABALXB17iRoigAAAAAAoE4IgpwEQRAAAAAAgDohCHISzAgCAAAAAFAnBEFOgkwQAAAAAIA6KRoEzZ49mwYMGEAREREUFxdHV155JR0+fJg8AYIgAAAAAAB1UjQIWrduHd1///20ZcsWWrFiBdXW1tK4ceOovLyc3B0GpQIAAAAAqJO/kg++bNkyo3/PnTtXZIR27txJI0aMaLB9VVWVeJOUlJSI9/X19eJNSfz4Go1Gvx/nKqrF+8hgf8X3DdTJ9JgBwDEDOM+A0vDaBO58zNizD4oGQaaKi4vF++joaIvlc7NmzWrw+by8PKqsrCSln3Tefz4IfH19Kfdcmfi8b20l5ebmKrpvoE6mxwwAjhnAeQaUhtcmcOdjprS01P2CIH7iZsyYQcOHD6fu3bub3WbmzJliG8NMUFJSEsXGxlJkZCQpfQD4+PiIfeEDoLI+Q3y+VVxzkd0CaOyYAbD3PAOAYwbkhvMMuPMxExwc7H5B0AMPPEB79+6ljRs3WtwmKChIvJniJ1zpJ53xASDtS0lljfhc89AgVewbqJPhMQOAYwZwngE1wGsTuOsxY8/jqyIIevDBB+nPP/+k9evXU+vWrckTYE4QAAAAAIA6+StdAscB0IIFC2jt2rXUtm1b8hRokQ0AAAAAoE6KBkHcHvvHH3+kP/74Q8wKOnv2rPh8VFQUhYSEkLuqq9dQaWWt+DgqJEDp3QEAAAAAAAOKFu7NmTNHdJMYNWoUJSYm6t/mzZtH7qxUtx6IIQgCAAAAAFAXxcvhPJFUChcS4EeB/ljwDgAAAACgJrhCdwKsBwIAAAAAUC8EQU6AIAgAAAAAQL0QBDkBgiAAAAAAAPVCEOQEmBEEAAAAAKBeCIKcAJkgAAAAAAD1QhDkBAiCAAAAAADUC0GQE5ToWmRjRhAAAAAAgPogCHJqJkjRMUwAAAAAAGAGgiBnBkGhAc749gAAAAAA0AQIgpwAa4IAAAAAANQLQZATIAgCAAAAAFAvBEFOUFyBxggAAAAAAGqFIEhm9fUaKq2qFR9HhmBNEAAAAACA2iAIkhkHQBqN9mO0yAYAAAAAUB8EQU5aDxQc4EtB/n5yf3sAAAAAAGgiBEEyw6BUAAAAAAB1QxAkM3SGAwAAAABQNwRBMkMQBAAAAACgbgiCZFZSqe0Mh6YIAAAAAADqhCDISZkgtMcGAAAAAFAnBEEyQzkcAAAAAIC6IQiSGYIgAAAAAAB1QxAkM7TIBgAAAABQNwRBMkMmCAAAAABA3RAEyaz4PLrDAQAAAACoGYIgmaEcDgAAAABA3RAEyQzlcAAAAAAA6oYgSEb1Gg2VVGrnBGFYKgAAAACAOiEIklFFdT3Va7QfY1gqAAAAAIA6IQiSUUmltilCkL8vBQf4yfmtAQAAAABAJgiCZFRaVSfeoxQOAAAAAEC9EATJqLQK7bEBAAAAANQOQZCMSiqRCQIAAAAAUDsEQTJCORwAAAAAgPohCJJRqa4xAtYEAQAAAACoF4IgJ2SC0B4bAAAAAEC9EAQ5oUU2MkEAAAAAAOqFIEhGWBMEAAAAAKB+CIJkVIrucAAAAAAAqocgSEaYEwQAAAAAoH4IgmRUomuMEBUaIOe3BQAAAAAATwmC1q9fT5dddhm1bNmSfHx8aOHCheTO0CIbAAAAAED9FA2CysvLqVevXvTRRx+Ru9NoNFQmZYJCkAkCAAAAAFArfyUffMKECeLNE5RV1VKdRvsxgiAAAAAAAPVSNAiyV1VVlXiTlJSUiPf19fXiTUnnyqvF+wA/Hwrw1e4TgDV8jHAGEccK2ArHDNgLxwzgmAFvOs/U27EPbhUEzZ49m2bNmtXg83l5eVRZWUlKSs8pE+8jgvzE/gDY8odaXFwsThy+vuhRAo3DMQP2wjEDOGbAm84zpaWlnhkEzZw5k2bMmGGUCUpKSqLY2FiKjIxUdN+OlviI983DgiguLk7RfQH3OWlwQxA+fpU+aYB7wDEDOGYA5xlQm3oVXc8EBwd7ZhAUFBQk3kzxE670k244KFXpfQH3wScNNRy/4D5wzACOGcB5BtTGRyXXM/Y8Pq68ZFJcWSPeR6IzHAAAAACAqimaCSorK6Njx47p/52enk67d++m6OhoatOmDbmTkvPaIAid4QAAAAAA1E3RIGjHjh00evRo/b+l9T7Tpk2jr7/+mtxJ8fla8T4qGDOCAAAAAADUTNEgaNSoUaKThCco1meC3GqZFQAAAACA18GaIJmDIKwJAgAAAABQNwRBMmkbE0o9EsMoKTpUrm8JAAAAAABOgNotmTx6SUe6qVczzAgCAAAAAFA5ZIIAAAAAAMCrIAgCAAAAAACvgiAIAAAAAAC8CoIgAAAAAADwKgiCAAAAAADAqyAIAgAAAAAAr4IgCAAAAAAAvAqCIAAAAAAA8CoIggAAAAAAwKsgCAIAAAAAAK+CIAgAAAAAALwKgiAAAAAAAPAqCIIAAAAAAMCrIAgCAAAAAACvgiAIAAAAAAC8CoIgAAAAAADwKgiCAAAAAADAqyAIAgAAAAAAr+JPbkyj0Yj3JSUlSu8K1dfXU2lpKQUHB5OvL2JLwDEDOM+A8vDaBDhmwJvOMyW6mECKETw2COInnCUlJSm9KwAAAAAAoJIYISoqyuo2PhpbQiUVR55nzpyhiIgI8vHxUTzy5GAsMzOTIiMjFd0XcA84ZgDHDOA8A2qD1yZw52OGwxoOgFq2bNloVsqtM0H8w7Vu3ZrUhH/5Sh8A4F5wzACOGcB5BtQGr03grsdMYxkgCRavAAAAAACAV0EQBAAAAAAAXgVBkEyCgoLoxRdfFO8BcMyAM+A8AzhmwNlwngFvOWbcujECAAAAAACAvZAJAgAAAAAAr4IgCAAAAAAAvAqCIAAAAAAA8CoIggAAAAAAwKsgCJLJ//73P2rbti0FBwdTv379aMOGDXJ9a/Aws2fPpgEDBlBERATFxcXRlVdeSYcPH1Z6t8CNjh8fHx965JFHlN4VULmsrCy6+eabKSYmhkJDQ6l37960c+dOpXcLVKq2tpaee+45cS0TEhJCqamp9PLLL1N9fb3SuwYqsX79errsssuoZcuW4nVo4cKFRv/PvdZeeukl8f98DI0aNYoOHDhAaoUgSAbz5s0TFyTPPvss/fvvv3TRRRfRhAkT6NSpU3J8e/Aw69ato/vvv5+2bNlCK1asEC8848aNo/LycqV3DVRu+/bt9Nlnn1HPnj2V3hVQuaKiIho2bBgFBATQ0qVLKS0tjd555x1q1qyZ0rsGKvXmm2/SJ598Qh999BEdPHiQ3nrrLXr77bfpww8/VHrXQCXKy8upV69e4hgxh4+Zd999V/w/v14lJCTQJZdcQqWlpaRGaJEtg0GDBlHfvn1pzpw5+s916dJF3OHnu7YA1uTl5YmMEAdHI0aMwJMFZpWVlYnzDGedX331VXFX/7333sOzBWY9/fTTtGnTJlQlgM0mT55M8fHx9OWXX+o/d80114gs4nfffYdnEoxwJmjBggXiWlfKAnEGiJMCTz31lPhcVVWVOKY4wL7nnntIbZAJaqLq6mpRXsB38g3xv//555+mfnvwAsXFxeJ9dHS00rsCKsbZw0mTJtHYsWOV3hVwA3/++Sf179+frrvuOnGTpU+fPvT5558rvVugYsOHD6dVq1bRkSNHxL/37NlDGzdupIkTJyq9a+AG0tPT6ezZs0bXwzw8deTIkaq9HvZXegfcXX5+PtXV1YlI1xD/mw8GAGv4zsmMGTPEi0/37t3xZIFZP//8M+3atUuUFwDY4sSJE6I6gc8vzzzzDG3bto0eeughcVFy66234kmEBvjuPd+U69y5M/n5+Ylrm9dee42mTp2KZwsaJV3zmrsePnnyJKkRgiAZ04KmF7emnwMw9cADD9DevXvF3TYAczIzM+nhhx+mv//+WzReAbAFL2bnTNDrr78u/s2ZIF6gzIERgiCwtL75+++/px9//JG6detGu3fvFqVNXOI0bdo0PGngcdfDCIKaqEWLFuKOiWnWJzc3t0E0DGDowQcfFCUr3G2ldevWeHLALC635fMJd52U8B1aPm548SnXXPM5CMBQYmIide3a1ehzvFb1999/xxMFZj3xxBNiLdkNN9wg/t2jRw9xB5/XNiMIgsZwEwTG18N8/nGH62GsCWqiwMBAcXHCXb4M8b+HDh3a1G8PHojvinAGaP78+bR69WrRjhTAkjFjxtC+ffvEXVnpje/w33TTTeJjBEBgDneGM229z2s9kpOT8YSBWRUVFeTra3xZyOcXtMgGW/C1DAdChtfDvG6emz6p9XoYmSAZcM31LbfcIi5MhgwZIlrYcnvse++9V45vDx64wJ3LDf744w8xK0jKIkZFRYm++gCG+BgxXS8WFhYmZr9gHRlY8uijj4oLDy6HmzJlilgTxK9N/AZgDs9/4TVAbdq0EeVwPPKD2x3ffvvteMJA36X02LFjRs0Q+GYcN3bi44bLJ/mc06FDB/HGH3N3wRtvvJFUSQOy+PjjjzXJycmawMBATd++fTXr1q3DMwtm8Z+dube5c+fiGQObjBw5UvPwww/j2QKrFi1apOnevbsmKChI07lzZ81nn32GZwwsKikpEeeVNm3aaIKDgzWpqamaZ599VlNVVYVnDYQ1a9aYvX6ZNm2a+P/6+nrNiy++qElISBDnnREjRmj27dunUSvMCQIAAAAAAK+CNUEAAAAAAOBVEAQBAAAAAIBXQRAEAAAAAABeBUEQAAAAAAB4FQRBAAAAAADgVRAEAQAAAACAV0EQBAAAAAAAXgVBEAAAAAAAeBUEQQAAoIiXXnqJevfu7fLHXbt2Lfn4+Ii3K6+80uZ9lb7mvffec/o+AgCAcyEIAgAA2UkBg6W36dOn0+OPP06rVq1S7Nk/fPgwff311zZty/uanZ1NrVu3dvp+AQCA8/m74DEAAMDLcMAgmTdvHr3wwgsi6JCEhIRQeHi4eFNKXFwcNWvWzKZtpX318/Nz+n4BAIDzIRMEAACyS0hI0L9FRUWJ7I/p50zL4Tg7xOVpr7/+OsXHx4sAZdasWVRbW0tPPPEERUdHi0zMV199ZfRYWVlZdP3111Pz5s0pJiaGrrjiCsrIyLB7n3/77Tfq0aOHCND4+4wdO5bKy8tleT4AAEBdEAQBAIBqrF69ms6cOUPr16+nd999VwRKkydPFgHO1q1b6d577xVvmZmZYvuKigoaPXq0yNLw12zcuFF8PH78eKqurrYrczV16lS6/fbb6eDBg2Ld0NVXX00ajcaJPy0AACgFQRAAAKgGZ3s++OAD6tSpkwhI+D0HOs888wx16NCBZs6cSYGBgbRp0yax/c8//0y+vr70xRdfiCxOly5daO7cuXTq1CkRyNgTBHHGiQOflJQU8b3uu+8+Rcv1AADAebAmCAAAVKNbt24iqJFwWVz37t31/+Y1OVyqlpubK/69c+dOOnbsGEVERBh9n8rKSjp+/LjNj9urVy8aM2aMCH4uvfRSGjduHF177bUiAwUAAJ4HQRAAAKhGQECA0b95LZG5z9XX14uP+X2/fv3ohx9+aPC9YmNjbX5cDq5WrFhB//zzD/3999/04Ycf0rPPPitK8Nq2bevwzwMAAOqEcjgAAHBbffv2paNHj4pOb+3btzd64+YL9uDgatiwYaIZw7///ivK7hYsWOC0fQcAAOUgCAIAALd10003UYsWLURHuA0bNlB6ejqtW7eOHn74YTp9+rTN34czPtyVbseOHWI90fz58ykvL0+sMQIAAM+DcjgAAHBboaGhoivcU089JZoalJaWUqtWrcT6nsjISJu/D2/L3+e9996jkpISSk5OpnfeeYcmTJjg1P0HAABl+GjQ/xMAALwId43jttpFRUU2D0uVcOe4Rx55RLwBAID7QjkcAAB4JR68yrOBbMGlctwum0vlAADA/SETBAAAXuX8+fOUlZUlPubAJiEhodGvKSwsFG9S1zl7my4AAIC6IAgCAAAAAACvgnI4AAAAAADwKgiCAAAAAADAqyAIAgAAAAAAr4IgCAAAAAAAvAqCIAAAAAAA8CoIggAAAAAAwKsgCAIAAAAAAK+CIAgAAAAAAMib/D/4osna8+LvJwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "\n",
+    "# Ensemble RMS time series\n",
+    "ens_rms_ts = ts.ensemble_rms\n",
+    "time_array = ens_rms_ts.get_time_vector()\n",
+    "rms_array = np.array(ens_rms_ts)\n",
+    "\n",
+    "plt.plot(time_array.value, rms_array, label='Ensemble RMS')\n",
+    "\n",
+    "# Add time mean as horizontal line\n",
+    "mean_val = ens_rms_ts.time_mean.value\n",
+    "plt.axhline(mean_val.value if hasattr(mean_val, 'value') else mean_val, \n",
+    "            color='r', linestyle='--', \n",
+    "            label=f'Time Mean = {mean_val:.2f}')\n",
+    "\n",
+    "plt.xlabel(f'Time [{time_array.unit}]')\n",
+    "plt.ylabel('Ensemble RMS [nm]')\n",
+    "plt.title('Ensemble RMS Evolution')\n",
+    "plt.legend()\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiple Statistical Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ensemble statistics (time-averaged):\n",
+      "  Mean:   0.73 nm\n",
+      "  RMS:    6.99 nm\n",
+      "  Std:    6.25 nm\n",
+      "  Median: 1.10 nm\n",
+      "  PTP:    18.67 nm\n",
+      "\n",
+      "Time statistics (ensemble-averaged):\n",
+      "  Mean:   0.73 nm\n",
+      "  RMS:    7.08 nm\n",
+      "  Std:    7.01 nm\n",
+      "  Median: 1.53 nm\n",
+      "  PTP:    22.67 nm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compare different ensemble statistics\n",
+    "print(\"Ensemble statistics (time-averaged):\")\n",
+    "print(f\"  Mean:   {ts.ensemble_mean.time_mean.value:.2f}\")\n",
+    "print(f\"  RMS:    {ts.ensemble_rms.time_mean.value:.2f}\")\n",
+    "print(f\"  Std:    {ts.ensemble_std.time_mean.value:.2f}\")\n",
+    "print(f\"  Median: {ts.ensemble_median.time_mean.value:.2f}\")\n",
+    "print(f\"  PTP:    {ts.ensemble_ptp.time_mean.value:.2f}\")\n",
+    "\n",
+    "print(\"\\nTime statistics (ensemble-averaged):\")\n",
+    "print(f\"  Mean:   {ts.time_mean.ensemble_mean.value:.2f}\")\n",
+    "print(f\"  RMS:    {ts.time_rms.ensemble_mean.value:.2f}\")\n",
+    "print(f\"  Std:    {ts.time_std.ensemble_mean.value:.2f}\")\n",
+    "print(f\"  Median: {ts.time_median.ensemble_mean.value:.2f}\")\n",
+    "print(f\"  PTP:    {ts.time_ptp.ensemble_mean.value:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Available Chainable Properties\n",
+    "\n",
+    "### Ensemble Operations (reduce across spatial dimension):\n",
+    "- `ensemble_rms` - Root mean square\n",
+    "- `ensemble_mean` - Arithmetic mean (renamed from ensemble_average)\n",
+    "- `ensemble_std` - Standard deviation\n",
+    "- `ensemble_median` - Median\n",
+    "- `ensemble_ptp` - Peak-to-peak (max - min)\n",
+    "\n",
+    "### Time Operations (reduce across temporal dimension):\n",
+    "- `time_mean` - Arithmetic mean (renamed from time_average)\n",
+    "- `time_std` - Standard deviation\n",
+    "- `time_rms` - Root mean square\n",
+    "- `time_median` - Median\n",
+    "- `time_ptp` - Peak-to-peak (max - min)\n",
+    "\n",
+    "### Other Operations:\n",
+    "- `filter(**kwargs)` - Generic filtering (accepts any Indexer parameters)\n",
+    "- `with_times(time_array)` - Time filtering (alias for filter)\n",
+    "- `.value` - Extract final array or scalar (like pandas)\n",
+    "- `.shape` - Data shape (like numpy arrays)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Migration from Legacy API\n",
+    "\n",
+    "Old methods are deprecated but still work:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ New fluent API result: [ 2.19996641e-01  2.09961742e+00  3.39490256e+00  4.27030948e+00\n",
+      "  4.30766264e+00  5.39150272e+00  4.54710282e+00  4.61826564e+00\n",
+      "  5.56762980e+00  6.37042634e+00  6.17383133e+00  7.25962883e+00\n",
+      "  7.55555086e+00  6.78807454e+00  5.84779210e+00  5.04213240e+00\n",
+      "  4.26189119e+00  3.22072931e+00  3.92292829e+00  3.71903052e+00\n",
+      "  4.93126120e+00  5.28521852e+00  5.71435941e+00  4.82830317e+00\n",
+      "  4.60360876e+00  3.89192590e+00  2.36012089e+00  1.44232510e+00\n",
+      "  1.02092429e+00  1.41482834e+00  1.50927069e+00  9.95677055e-01\n",
+      "  1.25304243e+00  8.17327675e-01  4.54282902e-01 -7.44360444e-01\n",
+      " -1.16676334e+00 -1.46087813e+00 -1.57683023e+00 -7.92364703e-01\n",
+      " -7.01484761e-02  3.01235724e-01  4.79947579e-01  5.27316444e-01\n",
+      "  4.84123606e-02 -1.36402558e+00 -2.31070676e+00 -1.88144724e+00\n",
+      " -2.84222952e+00 -2.31072486e+00 -2.01165688e+00 -2.30940016e+00\n",
+      " -2.94188622e+00 -2.77933510e+00 -3.57812926e+00 -4.49737467e+00\n",
+      " -4.77377487e+00 -4.48371066e+00 -3.96078727e+00 -3.13186344e+00\n",
+      " -1.87633972e+00 -7.97330364e-01 -4.35194222e-01  5.17902780e-01\n",
+      " -5.43916778e-01 -8.33410392e-01 -1.36839594e+00 -1.85364977e+00\n",
+      " -1.51922510e+00 -1.37702752e+00 -6.85327735e-01 -1.41848555e+00\n",
+      " -1.19439145e+00 -1.95616754e+00 -2.51418591e+00 -3.26275561e+00\n",
+      " -2.76775107e+00 -3.10780171e+00 -2.67555826e+00 -2.03351009e+00\n",
+      " -8.48840370e-02  4.63765304e-01  7.46569619e-01  9.08497967e-01\n",
+      "  9.72812203e-01  6.99505553e-01 -6.56714736e-03 -4.65466498e-01\n",
+      "  4.43539935e-01  1.09078308e+00  1.64657037e+00  1.96685943e+00\n",
+      "  2.44670723e+00  2.03586792e+00  1.20341618e+00  6.69076868e-01\n",
+      "  8.47249724e-01  1.02423897e+00  8.00737934e-01  1.84296448e+00] nm\n",
+      "\n",
+      "Migration examples:\n",
+      "  get_ensemble_average() → .ensemble_mean.value\n",
+      "  get_time_rms()         → .time_rms.value\n",
+      "  get_ensemble_rms()     → .ensemble_rms.value\n"
+     ]
+    }
+   ],
+   "source": [
+    "# OLD (deprecated - will show DeprecationWarning)\n",
+    "# old_result = ts.get_ensemble_average()\n",
+    "\n",
+    "# NEW (fluent API - recommended)\n",
+    "new_result = ts.ensemble_mean.value\n",
+    "\n",
+    "print(f\"✓ New fluent API result: {new_result}\")\n",
+    "print(\"\\nMigration examples:\")\n",
+    "print(\"  get_ensemble_average() → .ensemble_mean.value\")\n",
+    "print(\"  get_time_rms()         → .time_rms.value\")\n",
+    "print(\"  get_ensemble_rms()     → .ensemble_rms.value\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The fluent API provides:\n",
+    "\n",
+    "✅ **Expressive**: `ts.filter(modes=[2,3]).ensemble_rms.time_mean.value`\n",
+    "\n",
+    "✅ **Chainable**: All operations return TimeSeries until `.value` extraction\n",
+    "\n",
+    "✅ **Bidirectional**: Both ensemble→time and time→ensemble work\n",
+    "\n",
+    "✅ **Flexible**: Generic `filter(**kwargs)` accepts any Indexer parameters\n",
+    "\n",
+    "✅ **Familiar**: `.value` property like pandas, `.shape` like numpy\n",
+    "\n",
+    "See the [TimeSeries API documentation](../../time_series.html) for complete details."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "arte",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/time_series.rst
+++ b/docs/time_series.rst
@@ -20,6 +20,35 @@ These tools support:
 - Frequency domain analysis
 - Data merging and synchronization
 
+Fluent API
+----------
+
+The TimeSeries class provides a modern **chainable fluent API** for data analysis:
+
+**Chainable Properties:**
+
+- **Ensemble reductions**: ``ensemble_rms``, ``ensemble_mean``, ``ensemble_std``, ``ensemble_median``, ``ensemble_ptp``
+- **Time reductions**: ``time_mean``, ``time_std``, ``time_rms``, ``time_median``, ``time_ptp``
+- **Value extraction**: ``.value`` property (like pandas)
+- **Filtering**: ``filter(**kwargs)`` and ``with_times(times)``
+
+**Example:**
+
+.. code-block:: python
+
+    # Chainable operations
+    mean_rms = ts.filter(modes=[2,3,4]).ensemble_rms.time_mean.value
+    
+    # Bidirectional chaining
+    long_exposure = ts.time_mean.ensemble_rms.value
+
+See the :doc:`tutorial notebook <notebook/time_series/time_series_examples>` for detailed examples.
+
+**Legacy API:**
+
+Old methods (``ensemble_rms()``, ``time_average()``, etc.) have been renamed with ``get_`` prefix
+and marked deprecated. Use the new property-based API for new code.
+
 API Reference
 -------------
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,3 +28,11 @@ Utils
     :maxdepth: 4
 
     notebook/utils/discrete_fourier_transform
+
+Time Series
+-----------
+
+.. toctree::
+    :maxdepth: 4
+
+    notebook/time_series/time_series_examples

--- a/test/time_series/multi_time_series_test.py
+++ b/test/time_series/multi_time_series_test.py
@@ -130,5 +130,48 @@ class MultiTimeSeriesTest(unittest.TestCase):
         
         with self.assertWarns(DeprecationWarning):
             _ = multi.get_ensemble_median()
-
+        
+        with self.assertWarns(DeprecationWarning):
+            _ = multi.get_ensemble_rms()
+        
+        with self.assertWarns(DeprecationWarning):
+            _ = multi.get_ensemble_ptp()
+    
+    def test_deprecated_methods_check_homogeneity(self):
+        """Test that all deprecated ensemble methods check homogeneity"""
+        multi_hetero = AMultiTimeSeries(self.series1, self.series2)
+        multi_homo = AMultiTimeSeries(self.series1, self.series1b)
+        
+        # Heterogeneous series should raise for all deprecated methods
+        with self.assertRaises(Exception):
+            with self.assertWarns(DeprecationWarning):
+                _ = multi_hetero.get_ensemble_average()
+        
+        with self.assertRaises(Exception):
+            with self.assertWarns(DeprecationWarning):
+                _ = multi_hetero.get_ensemble_std()
+        
+        with self.assertRaises(Exception):
+            with self.assertWarns(DeprecationWarning):
+                _ = multi_hetero.get_ensemble_median()
+        
+        with self.assertRaises(Exception):
+            with self.assertWarns(DeprecationWarning):
+                _ = multi_hetero.get_ensemble_rms()
+        
+        with self.assertRaises(Exception):
+            with self.assertWarns(DeprecationWarning):
+                _ = multi_hetero.get_ensemble_ptp()
+        
+        # Homogeneous series should work for all (with warnings)
+        with self.assertWarns(DeprecationWarning):
+            _ = multi_homo.get_ensemble_average()
+        with self.assertWarns(DeprecationWarning):
+            _ = multi_homo.get_ensemble_std()
+        with self.assertWarns(DeprecationWarning):
+            _ = multi_homo.get_ensemble_median()
+        with self.assertWarns(DeprecationWarning):
+            _ = multi_homo.get_ensemble_rms()
+        with self.assertWarns(DeprecationWarning):
+            _ = multi_homo.get_ensemble_ptp()
 

--- a/test/time_series/multi_time_series_test.py
+++ b/test/time_series/multi_time_series_test.py
@@ -74,7 +74,61 @@ class MultiTimeSeriesTest(unittest.TestCase):
         multi2 = AMultiTimeSeries(self.series1, self.series1b)
 
         with self.assertRaises(Exception):
-            _ = multi1.ensemble_average()
+            _ = multi1.ensemble_mean
 
-        _ = multi2.ensemble_average()  # Does not raise
+        _ = multi2.ensemble_mean  # Does not raise
+    
+    def test_ensemble_properties_chainable(self):
+        """Test that ensemble properties are chainable and return TimeSeries"""
+        multi = AMultiTimeSeries(self.series1, self.series1b)
+        
+        # ensemble_mean is chainable
+        mean_series = multi.ensemble_mean
+        self.assertIsInstance(mean_series, TimeSeries)
+        
+        # Can chain with time operations
+        mean_then_time_mean = multi.ensemble_mean.time_mean
+        self.assertIsInstance(mean_then_time_mean, TimeSeries)
+        
+        # Can extract final value
+        final_value = multi.ensemble_mean.time_mean.value
+        self.assertTrue(np.isscalar(final_value) or isinstance(final_value, np.ndarray))
+    
+    def test_all_ensemble_properties_check_homogeneity(self):
+        """Test that all ensemble properties check homogeneity"""
+        multi_hetero = AMultiTimeSeries(self.series1, self.series2)
+        multi_homo = AMultiTimeSeries(self.series1, self.series1b)
+        
+        # Heterogeneous series should raise for all ensemble properties
+        with self.assertRaises(Exception):
+            _ = multi_hetero.ensemble_mean
+        with self.assertRaises(Exception):
+            _ = multi_hetero.ensemble_std
+        with self.assertRaises(Exception):
+            _ = multi_hetero.ensemble_median
+        with self.assertRaises(Exception):
+            _ = multi_hetero.ensemble_rms
+        with self.assertRaises(Exception):
+            _ = multi_hetero.ensemble_ptp
+        
+        # Homogeneous series should work for all
+        _ = multi_homo.ensemble_mean
+        _ = multi_homo.ensemble_std
+        _ = multi_homo.ensemble_median
+        _ = multi_homo.ensemble_rms
+        _ = multi_homo.ensemble_ptp
+    
+    def test_deprecated_methods_warn(self):
+        """Test that deprecated methods issue warnings"""
+        multi = AMultiTimeSeries(self.series1, self.series1b)
+        
+        with self.assertWarns(DeprecationWarning):
+            _ = multi.get_ensemble_average()
+        
+        with self.assertWarns(DeprecationWarning):
+            _ = multi.get_ensemble_std()
+        
+        with self.assertWarns(DeprecationWarning):
+            _ = multi.get_ensemble_median()
+
 

--- a/test/time_series/time_series_ma_test.py
+++ b/test/time_series/time_series_ma_test.py
@@ -47,17 +47,17 @@ class TimeSeriesMATest(unittest.TestCase):
         self.assertEqual(self._ts2d.time_size(), len(data2d))
 
     def test_timeAverage(self):
-        ta = self._ts2d.time_average()
+        ta = self._ts2d.time_mean.value
         np.testing.assert_almost_equal(ta, data2d.mean(axis=0))
         np.testing.assert_array_equal(ta.mask, m2d)
 
     def test_timeAverage_withTimes(self):
-        ta = self._ts2d.time_average(times=[1, 3])
+        ta = self._ts2d.filter(times=[1, 3]).time_mean.value
         np.testing.assert_almost_equal(ta, (data2d[1] + data2d[2])/2)
         np.testing.assert_array_equal(ta.mask, m2d)
 
     def test_ensemble_median(self):
-        np.testing.assert_almost_equal(self._ts2d.time_median(mode=0), np.median(data2d, axis=0))
+        np.testing.assert_almost_equal(self._ts2d.time_median.value, np.median(data2d, axis=0))
 
     def test_1d_correct_indexing(self):
         self._ts1d.get_index_of = lambda *args, **kwargs: 1
@@ -116,7 +116,7 @@ class TimeSeriesMATest(unittest.TestCase):
 
     def test_2d_mean(self):
         self._ts2d.get_index_of = lambda *args, **kwargs: None
-        np.testing.assert_array_almost_equal(self._ts2d.ensemble_average(), data2d.mean(axis=(1,2)))
+        np.testing.assert_array_almost_equal(self._ts2d.ensemble_mean.value, data2d.mean(axis=(1,2)))
 
     def test_2d_index(self):
         self._ts2d.get_index_of = lambda *args, **kwargs: RowColIndexer().rowcol(*args, **kwargs)

--- a/test/time_series/time_series_test.py
+++ b/test/time_series/time_series_test.py
@@ -526,6 +526,70 @@ class TimeSeriesTest(unittest.TestCase):
         rms_std_manual = np.sqrt(np.mean(time_std**2))
         self.assertAlmostEqual(rms_std_fluent, rms_std_manual)
     
+    def test_chainable_api_with_2d_ensemble(self):
+        """Test chainable API works with 2D ensemble (like wavefront maps)"""
+        ts = TimeSeries2D()
+        
+        # ts shape: (2, 3, 4) → 2 timesteps, 3×4 ensemble
+        
+        # ENSEMBLE → TIME: ensemble_rms collapses (3,4) → scalar per time
+        rms_series = ts.ensemble_rms
+        self.assertIsInstance(rms_series, TimeSeries)
+        rms_array = np.array(rms_series)
+        self.assertEqual(rms_array.ndim, 1)  # (2,) - time only
+        self.assertEqual(len(rms_array), 2)  # 2 timesteps
+        
+        # Then time_mean collapses time dimension
+        mean_rms = ts.ensemble_rms.time_mean.value
+        self.assertTrue(np.isscalar(mean_rms))
+        
+        # Manual verification
+        data = ts._get_not_indexed_data()
+        rms_manual = np.sqrt(np.mean(data**2, axis=(1, 2)))  # RMS over (3,4)
+        mean_manual = np.mean(rms_manual)  # Mean over time
+        self.assertAlmostEqual(mean_rms, mean_manual)
+    
+    def test_time_then_ensemble_with_2d_ensemble(self):
+        """Test TIME → ENSEMBLE direction with 2D ensemble"""
+        ts = TimeSeries2D()
+        
+        # TIME → ENSEMBLE: time_mean collapses time, preserves (3,4) ensemble
+        time_mean_series = ts.time_mean
+        self.assertIsInstance(time_mean_series, TimeSeries)
+        
+        time_mean_data = time_mean_series._get_not_indexed_data()
+        self.assertEqual(time_mean_data.shape, (1, 3, 4))  # time_size=1, ensemble preserved
+        
+        # Then ensemble_rms collapses (3,4) → scalar
+        rms_of_mean = ts.time_mean.ensemble_rms.value
+        self.assertTrue(np.isscalar(rms_of_mean))
+        
+        # Manual verification
+        data = ts._get_not_indexed_data()
+        time_avg = np.mean(data, axis=0)  # Shape: (3, 4)
+        rms_manual = np.sqrt(np.mean(time_avg**2))
+        self.assertAlmostEqual(rms_of_mean, rms_manual)
+    
+    def test_value_property_with_2d_ensemble(self):
+        """Test .value property returns correct shape for 2D ensemble"""
+        ts = TimeSeries2D()
+        
+        # time_mean should preserve 2D ensemble shape
+        time_mean_value = ts.time_mean.value
+        self.assertEqual(time_mean_value.shape, (3, 4))  # Squeezed (1,3,4) → (3,4)
+        
+        # time_std should also preserve 2D ensemble
+        time_std_value = ts.time_std.value
+        self.assertEqual(time_std_value.shape, (3, 4))
+        
+        # ensemble_rms should give 1D time array
+        rms_value = ts.ensemble_rms.value
+        self.assertEqual(rms_value.shape, (2,))  # 2 timesteps
+        
+        # Full chain should give scalar
+        scalar_value = ts.time_mean.ensemble_rms.value
+        self.assertTrue(np.isscalar(scalar_value))
+    
     def test_numpy_compatibility_on_chained_result(self):
         """Test that chained TimeSeries works with matplotlib/numpy"""
         ts = ATimeSeries(1 * u.s)

--- a/test/time_series/time_series_test.py
+++ b/test/time_series/time_series_test.py
@@ -803,6 +803,27 @@ class TimeSeriesTest(unittest.TestCase):
         # Should be equivalent to chained calls
         chained = ts.filter(modes=[2, 3, 4]).with_times([0.2 * u.s, 0.5 * u.s])
         np.testing.assert_array_equal(filtered_data, chained._get_not_indexed_data())
+    
+    def test_shape_property(self):
+        """Test that .shape property works like numpy arrays"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Full data shape
+        expected_shape = ts._get_not_indexed_data().shape
+        self.assertEqual(ts.shape, expected_shape)
+        
+        # After ensemble reduction (should collapse to 1D)
+        ens_rms = ts.ensemble_rms
+        self.assertEqual(len(ens_rms.shape), 1)
+        self.assertEqual(ens_rms.shape[0], ts.time_size())
+        
+        # After time reduction (should keep ensemble dimension)
+        time_mean = ts.time_mean
+        self.assertIn(ts.ensemble_size(), time_mean.shape)
+        
+        # After both reductions (scalar or near-scalar)
+        fully_reduced = ts.ensemble_rms.time_mean
+        self.assertTrue(len(fully_reduced.shape) <= 1)
         
         
 if __name__ == "__main__":

--- a/test/time_series/time_series_test.py
+++ b/test/time_series/time_series_test.py
@@ -171,7 +171,7 @@ class TimeSeriesTest(unittest.TestCase):
         self.assertAlmostEqual(ta[1], 1.)
 
     def test_ensemble_median(self):
-        np.testing.assert_almost_equal(self._ts.time_median(mode=0), 0)
+        np.testing.assert_almost_equal(self._ts.get_time_median(mode=0), 0)
 
     def test_times_kwonly(self):
         with self.assertRaises(IndexError):
@@ -247,7 +247,7 @@ class TimeSeriesTest(unittest.TestCase):
     def test_2d_mean(self):
         t2d = TimeSeries2D()
         t2d.get_index_of = lambda *args, **kwargs: None
-        np.testing.assert_array_almost_equal(t2d.ensemble_average(), (5.5, 17.5))
+        np.testing.assert_array_almost_equal(t2d.get_ensemble_average(), (5.5, 17.5))
 
     def test_2d_index(self):
         t2d = TimeSeries2D()
@@ -334,7 +334,7 @@ class TimeSeriesTest(unittest.TestCase):
         t1d.get_index_of = lambda: None
         # Data is [[0,1,2,3], [4,5,6,7], [8,9,10,11], [12,13,14,15], [16,17,18,19]]
         # time_ptp should give ptp along axis 0: [16,16,16,16]
-        ptp = t1d.time_ptp()
+        ptp = t1d.get_time_ptp()
         np.testing.assert_array_equal(ptp, [16, 16, 16, 16])
 
     def test_ensemble_ptp(self):
@@ -343,7 +343,7 @@ class TimeSeriesTest(unittest.TestCase):
         t1d.get_index_of = lambda: None
         # Data is [[0,1,2,3], [4,5,6,7], [8,9,10,11], [12,13,14,15], [16,17,18,19]]
         # ensemble_ptp should give ptp along axis 1: [3, 3, 3, 3, 3]
-        ptp = t1d.ensemble_ptp()
+        ptp = t1d.get_ensemble_ptp()
         np.testing.assert_array_equal(ptp, [3, 3, 3, 3, 3])
 
     def test_time_ptp_with_masked_array(self):
@@ -354,7 +354,7 @@ class TimeSeriesTest(unittest.TestCase):
             mask=[[0, 0, 1], [0, 0, 0], [0, 0, 0]]
         )
         t1d.get_index_of = lambda: None
-        ptp = t1d.time_ptp()
+        ptp = t1d.get_time_ptp()
         # Column 0: ptp([1, 4, 7]) = 6
         # Column 1: ptp([2, 5, 8]) = 6
         # Column 2: ptp([6, 9]) = 3 (masked value ignored)
@@ -369,7 +369,7 @@ class TimeSeriesTest(unittest.TestCase):
             mask=[[0, 0, 1], [0, 0, 0], [0, 0, 0]]
         )
         t1d.get_index_of = lambda: None
-        ptp = t1d.ensemble_ptp()
+        ptp = t1d.get_ensemble_ptp()
         # Row 0: ptp([1, 2]) = 1 (masked value ignored)
         # Row 1: ptp([4, 5, 6]) = 2
         # Row 2: ptp([7, 8, 9]) = 2
@@ -589,6 +589,68 @@ class TimeSeriesTest(unittest.TestCase):
         # Full chain should give scalar
         scalar_value = ts.time_mean.ensemble_rms.value
         self.assertTrue(np.isscalar(scalar_value))
+    
+    def test_all_ensemble_properties_chainable(self):
+        """Test that all ensemble properties are chainable"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # All should return TimeSeries
+        self.assertIsInstance(ts.ensemble_mean, TimeSeries)
+        self.assertIsInstance(ts.ensemble_std, TimeSeries)
+        self.assertIsInstance(ts.ensemble_median, TimeSeries)
+        self.assertIsInstance(ts.ensemble_ptp, TimeSeries)
+        
+        # All should be chainable with time operations
+        self.assertTrue(np.isscalar(ts.ensemble_mean.time_mean.value))
+        self.assertTrue(np.isscalar(ts.ensemble_std.time_std.value))
+        self.assertTrue(np.isscalar(ts.ensemble_median.time_median.value))
+        self.assertTrue(np.isscalar(ts.ensemble_ptp.time_ptp.value))
+    
+    def test_all_time_properties_chainable(self):
+        """Test that all time properties are chainable"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # All should return TimeSeries
+        self.assertIsInstance(ts.time_median, TimeSeries)
+        self.assertIsInstance(ts.time_rms, TimeSeries)
+        self.assertIsInstance(ts.time_ptp, TimeSeries)
+        
+        # All should be chainable with ensemble operations
+        self.assertTrue(np.isscalar(ts.time_median.ensemble_mean.value))
+        self.assertTrue(np.isscalar(ts.time_rms.ensemble_rms.value))
+        self.assertTrue(np.isscalar(ts.time_ptp.ensemble_ptp.value))
+    
+    def test_ensemble_mean_vs_legacy(self):
+        """Test ensemble_mean property matches get_ensemble_average"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # New property API
+        mean_new = ts.ensemble_mean.value
+        
+        # Legacy API (with warning suppression test)
+        with self.assertWarns(DeprecationWarning):
+            mean_old = ts.get_ensemble_average()
+        
+        np.testing.assert_array_almost_equal(mean_new, mean_old)
+    
+    def test_deprecated_methods_all_warn(self):
+        """Test that all legacy get_* methods raise DeprecationWarning"""
+        ts = ATimeSeries(1 * u.s)
+        
+        with self.assertWarns(DeprecationWarning):
+            ts.get_time_median()
+        with self.assertWarns(DeprecationWarning):
+            ts.get_time_rms()
+        with self.assertWarns(DeprecationWarning):
+            ts.get_time_ptp()
+        with self.assertWarns(DeprecationWarning):
+            ts.get_ensemble_average()
+        with self.assertWarns(DeprecationWarning):
+            ts.get_ensemble_std()
+        with self.assertWarns(DeprecationWarning):
+            ts.get_ensemble_median()
+        with self.assertWarns(DeprecationWarning):
+            ts.get_ensemble_ptp()
     
     def test_numpy_compatibility_on_chained_result(self):
         """Test that chained TimeSeries works with matplotlib/numpy"""

--- a/test/time_series/time_series_test.py
+++ b/test/time_series/time_series_test.py
@@ -804,6 +804,40 @@ class TimeSeriesTest(unittest.TestCase):
         chained = ts.filter(modes=[2, 3, 4]).with_times([0.2 * u.s, 0.5 * u.s])
         np.testing.assert_array_equal(filtered_data, chained._get_not_indexed_data())
     
+    def test_filter_times_validation_in_time_vector(self):
+        """Test that FilteredTimeSeries._get_time_vector validates times parameter"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Invalid times: not a sequence
+        with self.assertRaises(TimeSeriesException):
+            filtered = ts.filter(times=1.0)
+            _ = filtered.get_time_vector()  # Should raise when accessing time vector
+        
+        # Invalid times: wrong length
+        with self.assertRaises(TimeSeriesException):
+            filtered = ts.filter(times=[1.0, 2.0, 3.0])
+            _ = filtered.get_time_vector()  # Should raise when accessing time vector
+    
+    def test_filter_times_unit_conversion_in_time_vector(self):
+        """Test that FilteredTimeSeries._get_time_vector converts time units correctly"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Filter with float times (no units) - should work and convert to parent's units
+        filtered = ts.with_times([0.2, 0.5])
+        filtered_time = filtered.get_time_vector()
+        
+        # Time vector should still be a Quantity with parent's units
+        self.assertIsInstance(filtered_time, u.Quantity)
+        self.assertEqual(filtered_time.unit, u.s)
+        
+        # Values should be correctly filtered
+        self.assertTrue(np.all(filtered_time >= 0.2 * u.s))
+        self.assertTrue(np.all(filtered_time < 0.5 * u.s))
+        
+        # Should match get_data() behavior
+        filtered_data = filtered._get_not_indexed_data()
+        self.assertEqual(len(filtered_time), len(filtered_data))
+    
     def test_shape_property(self):
         """Test that .shape property works like numpy arrays"""
         ts = ATimeSeries(1 * u.s)

--- a/test/time_series/time_series_test.py
+++ b/test/time_series/time_series_test.py
@@ -824,6 +824,51 @@ class TimeSeriesTest(unittest.TestCase):
         # After both reductions (scalar or near-scalar)
         fully_reduced = ts.ensemble_rms.time_mean
         self.assertTrue(len(fully_reduced.shape) <= 1)
+    
+    def test_axes_preserved_in_temporal_reductions(self):
+        """Test that axes metadata is preserved in temporal reduction operations"""
+        
+        # Create TimeSeries with named axes
+        class TimeSeriesWithAxes(TimeSeries):
+            def __init__(self):
+                super().__init__(axes=('rows', 'cols'))
+                
+            def _get_not_indexed_data(self):
+                return np.arange(2*3*4).reshape(2, 3, 4)  # (time, rows, cols)
+            
+            def get_index_of(self, *args, **kwargs):
+                return None
+        
+        ts = TimeSeriesWithAxes()
+        
+        # Verify parent has axes
+        self.assertEqual(ts.axes, ('rows', 'cols'))
+        
+        # Test time_mean preserves axes
+        time_mean = ts.time_mean
+        self.assertEqual(time_mean.axes, ('rows', 'cols'))
+        
+        # Test time_std preserves axes
+        time_std = ts.time_std
+        self.assertEqual(time_std.axes, ('rows', 'cols'))
+        
+        # Test time_median preserves axes
+        time_median = ts.time_median
+        self.assertEqual(time_median.axes, ('rows', 'cols'))
+        
+        # Test time_rms preserves axes
+        time_rms = ts.time_rms
+        self.assertEqual(time_rms.axes, ('rows', 'cols'))
+        
+        # Test time_ptp preserves axes
+        time_ptp = ts.time_ptp
+        self.assertEqual(time_ptp.axes, ('rows', 'cols'))
+        
+        # Test chained operations preserve axes
+        chained = ts.ensemble_mean.time_mean
+        # After ensemble_mean, axes should be None or empty tuple (ensemble collapsed)
+        # So chained.axes should be None or ()
+        self.assertIn(chained.axes, (None, ()))
         
         
 if __name__ == "__main__":

--- a/test/time_series/time_series_test.py
+++ b/test/time_series/time_series_test.py
@@ -163,11 +163,11 @@ class TimeSeriesTest(unittest.TestCase):
                        f"Spectral variance: {spectral_var:.4e}")
 
     def test_timeAverage(self):
-        ta = self._ts.time_average()
+        ta = self._ts.get_time_average()
         self.assertAlmostEqual(ta[1], 1.)
 
     def test_timeAverage_withTimes(self):
-        ta = self._ts.time_average(times=[0.1, 0.3])
+        ta = self._ts.get_time_average(times=[0.1, 0.3])
         self.assertAlmostEqual(ta[1], 1.)
 
     def test_ensemble_median(self):
@@ -175,7 +175,7 @@ class TimeSeriesTest(unittest.TestCase):
 
     def test_times_kwonly(self):
         with self.assertRaises(IndexError):
-            _ = self._ts.time_average([0.1, 0.3])
+            _ = self._ts.get_time_average([0.1, 0.3])
 
     def test_1d_data(self):
         t1d = TimeSeries1D()
@@ -205,7 +205,7 @@ class TimeSeriesTest(unittest.TestCase):
     def test_2d_data(self):
         t2d = TimeSeries2D()
         assert t2d.time_size() == 2
-        np.testing.assert_equal(t2d.time_average(), np.arange(3*4).reshape(3,4)+6)
+        np.testing.assert_equal(t2d.get_time_average(), np.arange(3*4).reshape(3,4)+6)
 
     def test_2d_correct_indexing(self):
         t2d = TimeSeries2D()
@@ -387,7 +387,7 @@ class TimeSeriesTest(unittest.TestCase):
         # Row 2: RMS([8,9,10,11]) = sqrt(mean([64,81,100,121])) = sqrt(91.5)
         # Row 3: RMS([12,13,14,15]) = sqrt(mean([144,169,196,225])) = sqrt(183.5)
         # Row 4: RMS([16,17,18,19]) = sqrt(mean([256,289,324,361])) = sqrt(307.5)
-        rms = t1d.ensemble_rms()
+        rms = t1d.get_ensemble_rms()
         expected = np.array([np.sqrt(3.5), np.sqrt(31.5), np.sqrt(91.5), 
                             np.sqrt(183.5), np.sqrt(307.5)])
         np.testing.assert_array_almost_equal(rms, expected)
@@ -400,12 +400,283 @@ class TimeSeriesTest(unittest.TestCase):
             mask=[[0, 0, 1], [0, 0, 0], [0, 0, 0]]
         )
         t1d.get_index_of = lambda: None
-        rms = t1d.ensemble_rms()
+        rms = t1d.get_ensemble_rms()
         # Row 0: RMS([1, 2]) = sqrt(mean([1, 4])) = sqrt(2.5) (masked value ignored)
         # Row 1: RMS([4, 5, 6]) = sqrt(mean([16, 25, 36])) = sqrt(77/3)
         # Row 2: RMS([7, 8, 9]) = sqrt(mean([49, 64, 81])) = sqrt(194/3)
         expected = np.ma.array([np.sqrt(2.5), np.sqrt(77/3), np.sqrt(194/3)])
         np.testing.assert_array_almost_equal(rms, expected)
+
+    # --- PoC Fluent API Tests ---
+    
+    def test_array_protocol(self):
+        """Test __array__ protocol for numpy compatibility"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # __array__ should return the underlying data
+        array_data = np.array(ts)
+        expected_data = ts._get_not_indexed_data()
+        np.testing.assert_array_equal(array_data, expected_data)
+        
+        # Should work with numpy functions
+        mean = np.mean(ts)
+        expected_mean = np.mean(ts._get_not_indexed_data())
+        self.assertAlmostEqual(mean, expected_mean)
+        
+        # Test dtype conversion
+        array_float32 = np.array(ts, dtype=np.float32)
+        self.assertEqual(array_float32.dtype, np.float32)
+    
+    def test_ensemble_rms_returns_timeseries(self):
+        """Test ensemble_rms returns chainable TimeSeries"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Property should return TimeSeries, not array
+        rms_series = ts.ensemble_rms
+        self.assertIsInstance(rms_series, TimeSeries)
+        
+        # But should work like array via __array__ protocol
+        rms_array = np.array(rms_series)
+        self.assertIsInstance(rms_array, np.ndarray)
+        
+        # Should match old method output
+        rms_method = ts.get_ensemble_rms()
+        np.testing.assert_array_almost_equal(rms_array, rms_method)
+    
+    def test_time_mean_property(self):
+        """Test time_mean property (chainable operation)"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Property should return TimeSeries (chainable)
+        mean_ts = ts.time_mean
+        self.assertIsInstance(mean_ts, TimeSeries)
+        
+        # Extract value to compare with old method
+        mean = mean_ts.value
+        
+        # Should match old method output
+        mean_method = ts.get_time_average()
+        np.testing.assert_array_almost_equal(mean, mean_method)
+    
+    def test_time_std_property(self):
+        """Test time_std property (chainable operation)"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Property should return TimeSeries (chainable)
+        std_ts = ts.time_std
+        self.assertIsInstance(std_ts, TimeSeries)
+        
+        # Extract value to compare with old method
+        std = std_ts.value
+        
+        # Should match old method output
+        std_method = ts.get_time_std()
+        np.testing.assert_array_almost_equal(std, std_method)
+    
+    def test_chainable_api_fluent(self):
+        """Test fluent/chainable API: ts.ensemble_rms.time_mean.value"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # THE GOAL: fluent one-liner with .value extraction
+        mean_rms_ts = ts.ensemble_rms.time_mean
+        self.assertIsInstance(mean_rms_ts, TimeSeries)  # Still chainable
+        
+        mean_rms_fluent = mean_rms_ts.value  # Extract final scalar
+        
+        # Should be a scalar (or small array)
+        self.assertTrue(np.isscalar(mean_rms_fluent) or isinstance(mean_rms_fluent, np.ndarray))
+        
+        # Should match doing it step-by-step with old API
+        rms_array = ts.get_ensemble_rms()
+        mean_rms_old = np.mean(rms_array)
+        self.assertAlmostEqual(mean_rms_fluent, mean_rms_old)
+    
+    def test_chainable_api_with_std(self):
+        """Test chaining ensemble_rms.time_std.value"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Fluent API with .value extraction
+        std_rms_fluent = ts.ensemble_rms.time_std.value
+        
+        # Old API equivalent
+        rms_array = ts.get_ensemble_rms()
+        std_rms_old = np.std(rms_array)
+        
+        self.assertAlmostEqual(std_rms_fluent, std_rms_old)
+    
+    def test_time_then_ensemble_operations(self):
+        """Test chaining time reductions followed by ensemble operations.
+        
+        Example: ts.time_mean.ensemble_rms gives RMS of long-exposure.
+        """
+        ts = ATimeSeries(1 * u.s)
+        
+        # time_mean collapses temporal dimension, then ensemble_rms on result
+        rms_fluent = ts.time_mean.ensemble_rms.value
+        
+        # Equivalent manual computation using old API
+        time_avg = ts.get_time_average()  # shape: (ensemble,)
+        rms_manual = np.sqrt(np.mean(time_avg**2))
+        
+        self.assertAlmostEqual(rms_fluent, rms_manual)
+        
+        # time_std followed by ensemble_rms
+        rms_std_fluent = ts.time_std.ensemble_rms.value
+        time_std = ts.get_time_std()
+        rms_std_manual = np.sqrt(np.mean(time_std**2))
+        self.assertAlmostEqual(rms_std_fluent, rms_std_manual)
+    
+    def test_numpy_compatibility_on_chained_result(self):
+        """Test that chained TimeSeries works with matplotlib/numpy"""
+        ts = ATimeSeries(1 * u.s)
+        rms_series = ts.ensemble_rms
+        
+        # Should work with np.mean (via __array__)
+        mean = np.mean(rms_series)
+        self.assertTrue(np.isfinite(mean))
+        
+        # Should work with numpy indexing
+        first = rms_series[0]
+        self.assertTrue(np.isfinite(first))
+        
+        # Should work with matplotlib (simulated via np.asarray)
+        as_array = np.asarray(rms_series)
+        self.assertIsInstance(as_array, np.ndarray)
+    
+    def test_reduced_series_preserves_time_vector(self):
+        """Test that reduced series preserves time vector from parent"""
+        ts = ATimeSeries(1 * u.s)
+        rms_series = ts.ensemble_rms
+        
+        # Time vector should be inherited
+        parent_time = ts.get_time_vector()
+        reduced_time = rms_series.get_time_vector()
+        np.testing.assert_array_equal(parent_time, reduced_time)
+        
+        # Delta time should also be preserved
+        self.assertEqual(ts.delta_time, rms_series.delta_time)
+    
+    # --- Upstream Filtering Tests (Opzione 3) ---
+    
+    def test_filter_with_modes(self):
+        """Test filter(modes=...) upstream filtering"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Filter to specific modes
+        filtered = ts.filter(modes=[2, 3, 4])
+        self.assertIsInstance(filtered, TimeSeries)
+        
+        # Filtered data should have fewer modes
+        filtered_data = filtered._get_not_indexed_data()
+        original_shape = ts._get_not_indexed_data().shape
+        self.assertEqual(filtered_data.shape[0], original_shape[0])  # same time length
+        self.assertEqual(filtered_data.shape[1], 3)  # 3 modes selected
+        
+        # Should match old API
+        old_api_data = ts.get_data(modes=[2, 3, 4])
+        np.testing.assert_array_equal(filtered_data, old_api_data)
+    
+    def test_with_times_filtering(self):
+        """Test with_times() upstream filtering"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Filter time range
+        filtered = ts.with_times(times=[0.2 * u.s, 0.5 * u.s])
+        self.assertIsInstance(filtered, TimeSeries)
+        
+        # Filtered data should have fewer time steps
+        filtered_data = filtered._get_not_indexed_data()
+        original_shape = ts._get_not_indexed_data().shape
+        self.assertLess(filtered_data.shape[0], original_shape[0])
+        self.assertEqual(filtered_data.shape[1], original_shape[1])  # same modes
+        
+        # Time vector should be filtered too
+        filtered_time = filtered.get_time_vector()
+        self.assertTrue(np.all(filtered_time >= 0.2 * u.s))
+        self.assertTrue(np.all(filtered_time < 0.5 * u.s))
+    
+    def test_chained_filtering_modes_and_times(self):
+        """Test chaining: filter(modes=...).with_times()"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Chain mode and time filtering
+        filtered = ts.filter(modes=[2, 3, 4]).with_times([0.2 * u.s, 0.5 * u.s])
+        self.assertIsInstance(filtered, TimeSeries)
+        
+        filtered_data = filtered._get_not_indexed_data()
+        original_shape = ts._get_not_indexed_data().shape
+        
+        # Should have both filters applied
+        self.assertLess(filtered_data.shape[0], original_shape[0])  # time filtered
+        self.assertEqual(filtered_data.shape[1], 3)  # mode filtered
+        
+        # Should match old API with both filters
+        old_api_data = ts.get_data(modes=[2, 3, 4], times=[0.2 * u.s, 0.5 * u.s])
+        np.testing.assert_array_equal(filtered_data, old_api_data)
+    
+    def test_fluent_api_with_upstream_filtering(self):
+        """Test fluent API: filter(modes=..., times=...).ensemble_rms.time_mean.value"""
+        # Use faster sampling for this test (more samples)
+        ts = ATimeSeries(0.01 * u.s)  # 100 Hz, 100 samples
+        
+        # Fluent chain with upstream filtering (combined filter)
+        result_fluent = ts.filter(modes=[2, 3, 4], times=[0.2 * u.s, 0.5 * u.s]).ensemble_rms.time_mean.value
+        
+        # Old API equivalent
+        rms_old = ts.get_ensemble_rms(modes=[2, 3, 4], times=[0.2 * u.s, 0.5 * u.s])
+        result_old = np.mean(rms_old)
+        
+        # Should match
+        self.assertAlmostEqual(result_fluent, result_old, places=10)
+    
+    def test_ensemble_rms_on_filtered_series(self):
+        """Test that ensemble_rms works correctly on filtered series"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Get RMS of filtered modes
+        rms_series = ts.filter(modes=[2, 3, 4]).ensemble_rms
+        self.assertIsInstance(rms_series, TimeSeries)
+        
+        # Should be 1D (time only, ensemble collapsed)
+        rms_array = np.array(rms_series)
+        self.assertEqual(rms_array.ndim, 1)
+        self.assertEqual(len(rms_array), len(ts.get_time_vector()))
+        
+        # Values should match old API
+        rms_old = ts.get_ensemble_rms(modes=[2, 3, 4])
+        np.testing.assert_array_almost_equal(rms_array, rms_old)
+    
+    def test_filter_chainable_multiple_times(self):
+        """Test that filter() can be called multiple times (last wins)"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Apply filtering twice (second should override)
+        filtered = ts.filter(modes=[0, 1]).filter(modes=[2, 3, 4])
+        
+        filtered_data = filtered._get_not_indexed_data()
+        self.assertEqual(filtered_data.shape[1], 3)  # Only [2,3,4], not [0,1]
+        
+        # Should match last filter
+        expected = ts.get_data(modes=[2, 3, 4])
+        np.testing.assert_array_equal(filtered_data, expected)
+    
+    def test_filter_combined_modes_and_times(self):
+        """Test filter() with both modes and times in single call"""
+        ts = ATimeSeries(1 * u.s)
+        
+        # Single filter() call with both kwargs
+        filtered = ts.filter(modes=[2, 3, 4], times=[0.2 * u.s, 0.5 * u.s])
+        self.assertIsInstance(filtered, TimeSeries)
+        
+        filtered_data = filtered._get_not_indexed_data()
+        
+        # Should match old API with both filters
+        expected = ts.get_data(modes=[2, 3, 4], times=[0.2 * u.s, 0.5 * u.s])
+        np.testing.assert_array_equal(filtered_data, expected)
+        
+        # Should be equivalent to chained calls
+        chained = ts.filter(modes=[2, 3, 4]).with_times([0.2 * u.s, 0.5 * u.s])
+        np.testing.assert_array_equal(filtered_data, chained._get_not_indexed_data())
         
         
 if __name__ == "__main__":


### PR DESCRIPTION
# Fluent API for TimeSeries

## 📋 Summary

Implements a chainable fluent API for `TimeSeries` analysis, replacing method-based operations with property-based chainable operations. All statistical reductions now return `TimeSeries` objects that can be chained together, with a `.value` property for final extraction.

## 🎯 Motivation

**Before:**
```python
rms_array = ts.ensemble_rms(modes=[2,3,4])
mean_rms = np.mean(rms_array)
```

**After:**
```python
mean_rms = ts.filter(modes=[2,3,4]).ensemble_rms.time_mean.value
```

## ✨ Features

### Chainable Properties
All reduction operations are now **chainable properties** returning `TimeSeries`:

**Ensemble reductions:**
- `ensemble_rms` - RMS across ensemble
- `ensemble_mean` - Mean (renamed from `ensemble_average`)
- `ensemble_std` - Standard deviation
- `ensemble_median` - Median
- `ensemble_ptp` - Peak-to-peak

**Time reductions:**
- `time_mean` - Mean (renamed from `time_average`)
- `time_std` - Standard deviation
- `time_rms` - RMS
- `time_median` - Median
- `time_ptp` - Peak-to-peak

### New Capabilities

- **`.value` property**: Extract final values (like pandas `.values`)
- **Bidirectional chaining**: `ts.ensemble_rms.time_mean` and `ts.time_mean.ensemble_rms` both work
- **`filter(**kwargs)`**: Generic upstream filtering
  - Accepts any Indexer kwargs: `modes=`, `elements=`, `rows=`, `cols=`, `times=`, etc.
- **`with_times(times)`**: Convenient alias for `filter(times=...)`

## 📝 Examples

```python
# Basic chaining
mean_rms = ts.ensemble_rms.time_mean.value  # → scalar

# Upstream filtering
result = ts.filter(modes=[2,3,4], times=[1.0, 2.0]).ensemble_rms.time_mean.value

# Time-then-ensemble (NEW!)
long_exposure_ptp = ts.time_mean.ensemble_ptp.value

# Intermediate chainable results
rms_series = ts.filter(modes=[2,3,4]).ensemble_rms  # → TimeSeries
mean = rms_series.time_mean.value  # → scalar
```

## ⚠️ Breaking Changes

**All reduction methods renamed with `get_` prefix:**

| Old Method | Deprecated Method | New Property |
|------------|-------------------|--------------|
| `ts.ensemble_rms()` | `ts.get_ensemble_rms()` | `ts.ensemble_rms.value` |
| `ts.ensemble_average()` | `ts.get_ensemble_average()` | `ts.ensemble_mean.value` |
| `ts.time_average()` | `ts.get_time_average()` | `ts.time_mean.value` |
| *(same for all reductions)* |

**Migration:**
1. **Quick fix**: `ts.method()` → `ts.get_method()` (shows `DeprecationWarning`)
2. **Recommended**: Migrate to new property API

## 🔄 Migration Guide

```python
# Old → Deprecated → New
ts.ensemble_rms()                    → ts.get_ensemble_rms()           → ts.ensemble_rms.value
ts.ensemble_rms(modes=[2,3])        → ts.get_ensemble_rms(modes=[2,3]) → ts.filter(modes=[2,3]).ensemble_rms.value
np.mean(ts.ensemble_rms())          → np.mean(ts.get_ensemble_rms())   → ts.ensemble_rms.time_mean.value
ts.ensemble_average()                → ts.get_ensemble_average()        → ts.ensemble_mean.value
ts.time_average()                    → ts.get_time_average()            → ts.time_mean.value
```

## 🧪 Testing

- ✅ **72 tests passing** (68 original + 4 new)
- ⚠️ **21 DeprecationWarnings** (expected from legacy methods)
- **Coverage:**
  - All ensemble/time reductions
  - 1D ensemble (modal coefficients)
  - 2D ensemble (wavefront maps)
  - Bidirectional chaining
  - Filter combinations
  - MaskedArray support

## 📚 Documentation

- Main `TimeSeries` docstring updated with fluent API examples
- All properties have comprehensive docstrings
- Deprecation notices on all legacy `get_*()` methods

## 🔧 Implementation Details

- `_create_reduced_series()`: Handles ensemble reductions (preserves time axis)
- `_create_temporal_reduced_series()`: Handles time reductions (time_size=1)
- Time vector for temporal reductions: single timestamp = mean of parent times
- Compatible with `MaskedArray` and `astropy.units`

## 📦 Next Steps

- [ ] Update external packages (membranemirror, KADAT, CiaoCiao, etc.) to use `get_*()` or new API
- [ ] Add fluent API examples to user documentation



